### PR TITLE
Add AWS support to mdbd.

### DIFF
--- a/cmd/mdbd/daemon.go
+++ b/cmd/mdbd/daemon.go
@@ -21,7 +21,7 @@ type genericEncoder interface {
 	Encode(v interface{}) error
 }
 
-func runDaemon(sources []source, mdbFileName, hostnameRegex string,
+func runDaemon(generators []generator, mdbFileName, hostnameRegex string,
 	datacentre string, fetchInterval uint, logger *log.Logger, debug bool) {
 	var prevMdb *mdb.Mdb
 	var hostnameRE *regexp.Regexp
@@ -37,7 +37,7 @@ func runDaemon(sources []source, mdbFileName, hostnameRegex string,
 	fetchIntervalDuration := time.Duration(fetchInterval) * time.Second
 	for ; ; sleepUntil(cycleStopTime) {
 		cycleStopTime = time.Now().Add(fetchIntervalDuration)
-		newMdb, err := loadFromAll(sources, datacentre, logger)
+		newMdb, err := loadFromAll(generators, datacentre, logger)
 		if err != nil {
 			logger.Println(err)
 			continue
@@ -70,11 +70,11 @@ func sleepUntil(wakeTime time.Time) {
 	time.Sleep(sleepTime)
 }
 
-func loadFromAll(sources []source, datacentre string,
+func loadFromAll(generators []generator, datacentre string,
 	logger *log.Logger) (*mdb.Mdb, error) {
 	machineMap := make(map[string]mdb.Machine)
-	for _, source := range sources {
-		mdb, err := loadMdb(source.driverFunc, source.url, datacentre, logger)
+	for _, gen := range generators {
+		mdb, err := gen.Generate(datacentre, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mdbd/daemon.go
+++ b/cmd/mdbd/daemon.go
@@ -7,13 +7,11 @@ import (
 	"github.com/Symantec/Dominator/lib/json"
 	"github.com/Symantec/Dominator/lib/mdb"
 	"log"
-	"net/http"
 	"os"
 	"path"
 	"regexp"
 	"runtime"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -92,34 +90,6 @@ func loadFromAll(generators []generator, datacentre string,
 		newMdb.Machines = append(newMdb.Machines, machine)
 	}
 	return &newMdb, nil
-}
-
-func loadMdb(driverFunc driverFunc, url string, datacentre string,
-	logger *log.Logger) (
-	*mdb.Mdb, error) {
-	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		return loadHttpMdb(driverFunc, url, datacentre, logger)
-	}
-	file, err := os.Open(url)
-	if err != nil {
-		return nil, errors.New(("Error opening file " + err.Error()))
-	}
-	defer file.Close()
-	return driverFunc(bufio.NewReader(file), datacentre, logger)
-}
-
-func loadHttpMdb(driverFunc driverFunc, url string, datacentre string,
-	logger *log.Logger) (
-	*mdb.Mdb, error) {
-	response, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return nil, errors.New("HTTP get failed")
-	}
-	return driverFunc(response.Body, datacentre, logger)
 }
 
 func selectHosts(inMdb *mdb.Mdb, hostnameRE *regexp.Regexp) *mdb.Mdb {

--- a/cmd/mdbd/generators.go
+++ b/cmd/mdbd/generators.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"github.com/Symantec/Dominator/lib/mdb"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type driverFunc func(reader io.Reader, datacentre string,
+	logger *log.Logger) (*mdb.Mdb, error)
+
+// The generator interface generates an mdb from some source.
+type generator interface {
+	Generate(datacentre string, logger *log.Logger) (*mdb.Mdb, error)
+}
+
+// source implements the generator interface and generates an mdb from
+// either a flat file or a url.
+type source struct {
+	// The function parses the data from url or flat file.
+	driverFunc driverFunc
+	// the url or path of the flat file
+	url string
+}
+
+func (s source) Generate(
+	datacentre string, logger *log.Logger) (*mdb.Mdb, error) {
+	return loadMdb(s.driverFunc, s.url, datacentre, logger)
+}
+
+func loadMdb(driverFunc driverFunc, url string, datacentre string,
+	logger *log.Logger) (
+	*mdb.Mdb, error) {
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return loadHttpMdb(driverFunc, url, datacentre, logger)
+	}
+	file, err := os.Open(url)
+	if err != nil {
+		return nil, errors.New(("Error opening file " + err.Error()))
+	}
+	defer file.Close()
+	return driverFunc(bufio.NewReader(file), datacentre, logger)
+}
+
+func loadHttpMdb(driverFunc driverFunc, url string, datacentre string,
+	logger *log.Logger) (
+	*mdb.Mdb, error) {
+	response, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.New("HTTP get failed")
+	}
+	return driverFunc(response.Body, datacentre, logger)
+}

--- a/cmd/mdbd/loadAws.go
+++ b/cmd/mdbd/loadAws.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"github.com/Symantec/Dominator/lib/mdb"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"log"
+)
+
+type awsGeneratorType struct {
+	svc *ec2.EC2
+}
+
+func newAwsGenerator(datacentre string) (
+	result *awsGeneratorType, err error) {
+	sess, err := session.NewSession(
+		&aws.Config{Region: aws.String(datacentre)})
+	if err != nil {
+		return
+	}
+	svc := ec2.New(sess)
+	result = &awsGeneratorType{svc: svc}
+	return
+}
+
+func (g *awsGeneratorType) Generate(
+	unused_datacentre string, unused_logger *log.Logger) (
+	result *mdb.Mdb, err error) {
+	params := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []*string{aws.String("running")},
+			},
+		},
+	}
+	resp, err := g.svc.DescribeInstances(params)
+	if err != nil {
+		return
+	}
+	result = extractMdb(resp)
+	return
+}
+
+func extractMdb(output *ec2.DescribeInstancesOutput) *mdb.Mdb {
+	var result mdb.Mdb
+	for _, reservation := range output.Reservations {
+		for _, instance := range reservation.Instances {
+			if instance.PrivateDnsName != nil {
+				machine := mdb.Machine{
+					Hostname: *instance.PrivateDnsName}
+				extractTags(instance.Tags, &machine)
+				result.Machines = append(
+					result.Machines, machine)
+			}
+		}
+	}
+	return &result
+}
+
+func extractTags(tags []*ec2.Tag, machine *mdb.Machine) {
+	for _, tag := range tags {
+		switch *tag.Key {
+		case "RequiredImage":
+			if tag.Value != nil {
+				machine.RequiredImage = *tag.Value
+			}
+		case "PlannedImage":
+			if tag.Value != nil {
+				machine.PlannedImage = *tag.Value
+			}
+		case "DisableUpdates":
+			if tag.Value != nil {
+				machine.DisableUpdates = true
+			}
+		case "OwnerGroup":
+			if tag.Value != nil {
+				machine.OwnerGroup = *tag.Value
+			}
+		}
+	}
+}

--- a/cmd/mdbd/main.go
+++ b/cmd/mdbd/main.go
@@ -166,13 +166,8 @@ func main() {
 		}
 	}
 	for index := 0; index < flag.NArg(); index += 2 {
-		generators = append(
-			generators,
-			getSource(
-				flag.Arg(index),
-				flag.Arg(index+1)))
+		generators = append(generators,
+			getSource(flag.Arg(index), flag.Arg(index+1)))
 	}
-	runDaemon(
-		generators, *mdbFile, *hostnameRegex, *datacentre,
-		*fetchInterval, logger, *debug)
+	runDaemon(generators, *mdbFile, *hostnameRegex, *datacentre, *fetchInterval, logger, *debug)
 }

--- a/cmd/mdbd/main.go
+++ b/cmd/mdbd/main.go
@@ -42,6 +42,8 @@ func printUsage() {
 		"  ds.host.fqdn: JSON with map of map of hosts with fqdn entries")
 	fmt.Fprintln(os.Stderr,
 		"  text: each line contains: host required-image planned-image")
+	fmt.Fprintln(os.Stderr,
+		"  aws: Amazon AWS endpoint. url is datacenter like 'us-east-1'")
 }
 
 type driverFunc func(reader io.Reader, datacentre string,
@@ -56,6 +58,8 @@ var drivers = []driver{
 	{"cis", loadCis},
 	{"ds.host.fqdn", loadDsHostFqdn},
 	{"text", loadText},
+	// aws driver is handled as a special case for now. See getSource
+	// function in this file.
 }
 
 func getLogger() *log.Logger {
@@ -70,12 +74,36 @@ func getLogger() *log.Logger {
 	return log.New(os.Stderr, "", log.LstdFlags)
 }
 
-type source struct {
-	driverFunc driverFunc
-	url        string
+// The generator interface generates an mdb from some source.
+type generator interface {
+	Generate(datacentre string, logger *log.Logger) (*mdb.Mdb, error)
 }
 
-func getSource(driverName, url string) source {
+// source implements the generator interface and generates an mdb from
+// either a flat file or a url.
+type source struct {
+	// The function parses the data from url or flat file.
+	driverFunc driverFunc
+	// the url or path of the flat file
+	url string
+}
+
+func (s source) Generate(
+	datacentre string, logger *log.Logger) (*mdb.Mdb, error) {
+	return loadMdb(s.driverFunc, s.url, datacentre, logger)
+}
+
+func getSource(driverName, url string) generator {
+	// special case for aws.
+	if driverName == "aws" {
+		// With aws, we must know the datacentre up front
+		result, err := newAwsGenerator(url)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		return result
+	}
 	for _, driver := range drivers {
 		if driverName == driver.name {
 			return source{driver.driverFunc, url}
@@ -124,9 +152,14 @@ func main() {
 		printUsage()
 		os.Exit(2)
 	}
+	// We have to have at least one input.
+	if *sourcesFile == "" && flag.NArg() == 0 {
+		printUsage()
+		os.Exit(2)
+	}
 	logger := getLogger()
 	handleSignals(logger)
-	sources := make([]source, 0, flag.NArg()/2)
+	generators := make([]generator, 0, flag.NArg()/2)
 	if *sourcesFile != "" {
 		file, err := os.Open(*sourcesFile)
 		if err != nil {
@@ -140,7 +173,7 @@ func main() {
 				if fields[0][0] == '#' {
 					continue
 				}
-				sources = append(sources, getSource(fields[0], fields[1]))
+				generators = append(generators, getSource(fields[0], fields[1]))
 			}
 		}
 		if err := scanner.Err(); err != nil {
@@ -149,8 +182,13 @@ func main() {
 		}
 	}
 	for index := 0; index < flag.NArg(); index += 2 {
-		sources = append(sources, getSource(flag.Arg(index), flag.Arg(index+1)))
+		generators = append(
+			generators,
+			getSource(
+				flag.Arg(index),
+				flag.Arg(index+1)))
 	}
-	runDaemon(sources, *mdbFile, *hostnameRegex, *datacentre, *fetchInterval,
-		logger, *debug)
+	runDaemon(
+		generators, *mdbFile, *hostnameRegex, *datacentre,
+		*fetchInterval, logger, *debug)
 }

--- a/cmd/mdbd/main.go
+++ b/cmd/mdbd/main.go
@@ -43,7 +43,15 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr,
 		"  text: each line contains: host required-image planned-image")
 	fmt.Fprintln(os.Stderr,
-		"  aws: Amazon AWS endpoint. url is datacenter like 'us-east-1'")
+		"  aws: Amazon AWS endpoint. url is datacenter like 'us-east-1'.")
+	fmt.Fprintln(os.Stderr,
+		"       This driver requires the file ~/.aws/credentials which")
+	fmt.Fprintln(os.Stderr,
+		"       contains the amazon aws credentials. For additional")
+	fmt.Fprintln(os.Stderr,
+		"       information see:")
+	fmt.Fprintln(os.Stderr,
+		"       http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/sdkforgo-dg.pdf")
 }
 
 type driverFunc func(reader io.Reader, datacentre string,

--- a/cmd/mdbd/main.go
+++ b/cmd/mdbd/main.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"github.com/Symantec/Dominator/lib/mdb"
-	"io"
 	"log"
 	"log/syslog"
 	"os"
@@ -37,12 +35,6 @@ func printUsage() {
 	flag.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "Drivers:")
 	fmt.Fprintln(os.Stderr,
-		"  cis: Cloud Intelligence Service endpoint")
-	fmt.Fprintln(os.Stderr,
-		"  ds.host.fqdn: JSON with map of map of hosts with fqdn entries")
-	fmt.Fprintln(os.Stderr,
-		"  text: each line contains: host required-image planned-image")
-	fmt.Fprintln(os.Stderr,
 		"  aws: Amazon AWS endpoint. url is datacenter like 'us-east-1'.")
 	fmt.Fprintln(os.Stderr,
 		"       This driver requires the file ~/.aws/credentials which")
@@ -52,10 +44,13 @@ func printUsage() {
 		"       information see:")
 	fmt.Fprintln(os.Stderr,
 		"       http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/sdkforgo-dg.pdf")
+	fmt.Fprintln(os.Stderr,
+		"  cis: Cloud Intelligence Service endpoint")
+	fmt.Fprintln(os.Stderr,
+		"  ds.host.fqdn: JSON with map of map of hosts with fqdn entries")
+	fmt.Fprintln(os.Stderr,
+		"  text: each line contains: host required-image planned-image")
 }
-
-type driverFunc func(reader io.Reader, datacentre string,
-	logger *log.Logger) (*mdb.Mdb, error)
 
 type driver struct {
 	name       string
@@ -80,25 +75,6 @@ func getLogger() *log.Logger {
 		return log.New(s, "", 0)
 	}
 	return log.New(os.Stderr, "", log.LstdFlags)
-}
-
-// The generator interface generates an mdb from some source.
-type generator interface {
-	Generate(datacentre string, logger *log.Logger) (*mdb.Mdb, error)
-}
-
-// source implements the generator interface and generates an mdb from
-// either a flat file or a url.
-type source struct {
-	// The function parses the data from url or flat file.
-	driverFunc driverFunc
-	// the url or path of the flat file
-	url string
-}
-
-func (s source) Generate(
-	datacentre string, logger *log.Logger) (*mdb.Mdb, error) {
-	return loadMdb(s.driverFunc, s.url, datacentre, logger)
 }
 
 func getSource(driverName, url string) generator {


### PR DESCRIPTION
This adds aws support to mbdb. The driver name is "aws"; the url is the data center like "us-east-1" The aws driver does not support limiting results by datacenter as it currently grabs machine data from a single data center.