### PR TITLE
logbuf API changes to support binaries with sub commands.

### DIFF
--- a/lib/logbuf/impl.go
+++ b/lib/logbuf/impl.go
@@ -4,12 +4,14 @@ import (
 	"bufio"
 	"container/ring"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -19,6 +21,11 @@ const (
 	filePerms = syscall.S_IRUSR | syscall.S_IWUSR | syscall.S_IRGRP
 
 	timeLayout = "2006-01-02:15:04:05.999"
+)
+
+var (
+	kSoleLogBuffer *LogBuffer
+	kOnce          sync.Once
 )
 
 func newLogBuffer(length uint, dirname string, quota uint64) *LogBuffer {
@@ -316,4 +323,8 @@ func reverseStrings(strings []string) {
 		strings[index], strings[length-1-index] =
 			strings[length-1-index], strings[index]
 	}
+}
+
+func init() {
+	UseFlagSet(flag.CommandLine)
 }

--- a/lib/logbuf/impl.go
+++ b/lib/logbuf/impl.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -21,11 +20,6 @@ const (
 	filePerms = syscall.S_IRUSR | syscall.S_IWUSR | syscall.S_IRGRP
 
 	timeLayout = "2006-01-02:15:04:05.999"
-)
-
-var (
-	kSoleLogBuffer *LogBuffer
-	kOnce          sync.Once
 )
 
 func newLogBuffer(length uint, dirname string, quota uint64) *LogBuffer {


### PR DESCRIPTION
These are the changes I made to the logbuf API to make it work with consul.

The consul binary uses sub commands like consul agent --flag1=val1 --flag2=val2. Each sub command has its own set of flags. To avoid naming collisions with flags among sub commands, each sub command registers its flags with its own flag set and has its flag set to parse the command line. Unfortunately, flag sets don't play nicely with packages that register flags globally. When a flag set sees flags that aren't registered with it (even if those flags happen to be registered globally) when parsing, the parse fails. To remedy this problem, I introduced the logbuf.UseFlagSet() method so that logbuf can let a flag set know what flags it is expecting.

Simply creating the *LogBuffer causes all of consul's log output to be automatically redirected to the files it creates on disk. The log level filtering in consul just works as expected with the logbuf package. No special log filtering code is needed on the LogBuffer side for consul integration. Good job on this package!

Because consul never needs the *LogBuffer object they way scotty and Dominator do, calling logger := logBuf.New() results in a compile time error because consul never uses the logger variable. Just calling logBuf.New() won't work because the GC could reclaim the *LogBuffer object. To solve this problem, I introduced logbuf.Get() which either permanently creates the *LogBuffer object internally or simply returns the already created *LogBuffer object. The first, advantage of Get() over New() is that Get() enforces the singleton semantics of the Logger instance. The second advantage of Get is that if the client wants to ensure that the LogBuffer object is created without accidentally creating two, calling logbuf.Get() does the trick. I left logbuf.New() but it delegates to logbuf.Get(). 

Let me know what you think. Cheers.
