### PR TITLE
Log level API proposal.

### DIFF
--- a/lib/logbuf/api.go
+++ b/lib/logbuf/api.go
@@ -54,6 +54,13 @@ type LogBuffer struct {
 //                    written
 //  -logQuota:        Log quota in MiB. If exceeded, old logs are deleted.
 //                    If zero, the quota will be 16 KiB
+//  -minLogLevel      Minimum log level. A log message must have at least
+//                    this level to be recorded. Must be one of the predefined
+//                    levels out of logbuf/level package such as
+//                    TRACE, DEBUG, INFO, WARN, or ERR.
+//                    If it isn't one of these values, the default is record
+//                    all logs. See logbuf/level package for more details
+//                    on assigning a level to a log message.
 func New() *LogBuffer {
 	quota := uint64(*logQuota) << 20
 	if quota < 16384 {

--- a/lib/logbuf/level/api.go
+++ b/lib/logbuf/level/api.go
@@ -1,0 +1,48 @@
+// Package level contains utilities for dealing with log levels
+package level
+
+import (
+	"fmt"
+)
+
+// Level represents a log level
+type Level string
+
+const (
+	None  Level = ""
+	Trace Level = "TRACE"
+	Debug Level = "DEBUG"
+	Info  Level = "INFO"
+	Warn  Level = "WARN"
+	Err   Level = "ERR"
+)
+
+var (
+	// Order is the order of log levels from least to greatest.
+	Order = []Level{
+		None,
+		Trace,
+		Debug,
+		Info,
+		Warn,
+		Err,
+	}
+)
+
+// Assign assigns a log level to a message.
+// Assign(Warn, "Hi there!") -> "[WARN] hi there!"
+func Assign(level Level, message string) string {
+	if level != None {
+		return fmt.Sprintf("[%s] %s", level, message)
+	}
+	return message
+}
+
+// Extract extracts the log level from a log line. The only requirement is
+// that the log level be within the first pair of squre brackets. If no
+// pair of square brackets exists, Extract returns None. Note
+// that Extract(Assign(aLevel, aMessage)) -> aLevel.
+func Extract(logLine string) Level {
+	// TODO
+	return None
+}


### PR DESCRIPTION
This is my API proposal for adding levels to the logbuf package.

Usage is easy.

logger.Printf(level.Assign(level.Warn, "Using %d bytes of memory"\n"), memoryInBytes)
