### PR TITLE
Log level API proposal with Camillo's suggestion.

### DIFF
--- a/lib/logbuf/api.go
+++ b/lib/logbuf/api.go
@@ -54,6 +54,13 @@ type LogBuffer struct {
 //                    written
 //  -logQuota:        Log quota in MiB. If exceeded, old logs are deleted.
 //                    If zero, the quota will be 16 KiB
+//  -logLevel         Log level. A log message must have at least
+//                    this level to be recorded. Must be one of the predefined
+//                    levels out of logbuf/level package such as
+//                    TRACE, DEBUG, INFO, WARN, or ERR.
+//                    If it isn't one of these values, the default is record
+//                    all logs. See logbuf/level package for more details
+//                    on assigning a level to a log message.
 func New() *LogBuffer {
 	quota := uint64(*logQuota) << 20
 	if quota < 16384 {

--- a/lib/logbuf/level/api.go
+++ b/lib/logbuf/level/api.go
@@ -1,0 +1,67 @@
+// Package level contains utilities for dealing with log levels
+package level
+
+import (
+	"log"
+)
+
+// Level represents a log level
+type Level string
+
+const (
+	None  Level = ""
+	Trace Level = "TRACE"
+	Debug Level = "DEBUG"
+	Info  Level = "INFO"
+	Warn  Level = "WARN"
+	Err   Level = "ERR"
+)
+
+var (
+	// Order is the order of log levels from least to greatest.
+	Order = []Level{
+		None,
+		Trace,
+		Debug,
+		Info,
+		Warn,
+		Err,
+	}
+)
+
+// Print prints a message with given level to l. Arguments are handled in the
+// manner of fmt.Print
+func Print(l *log.Logger, level Level, v ...interface{}) {
+	l.Print(buildList(level, v)...)
+}
+
+// Printf prints a message with given level to l. Arguments are handled in the
+// manner of fmt.Printf
+func Printf(l *log.Logger, level Level, format string, v ...interface{}) {
+	l.Printf(assign(level, format), v...)
+}
+
+// Println prints a message with given level to l. Arguments are handled in the
+// manner of fmt.Println
+func Println(l *log.Logger, level Level, v ...interface{}) {
+	l.Println(buildList(level, v)...)
+}
+
+// Extract extracts the log level from a log line. The only requirement is
+// that the log level be within the first pair of squre brackets. If no
+// pair of square brackets exists, Extract returns None. Note
+// that Extract(Assign(aLevel, aMessage)) -> aLevel.
+func Extract(logLine string) Level {
+	// TODO
+	return None
+}
+
+func buildList(level Level, v []interface{}) []interface{} {
+	// TODO
+	return nil
+}
+
+func assign(level Level, format string) string {
+	// TODO
+	return ""
+}


### PR DESCRIPTION
Camillo suggested avoiding nested function calls when doing log levels and suggested replacing minLogLevel with simply logLevel. This PR contains the resulting API proposal.
