### PR TITLE
Add multi-point content injection support to imageserver content distribution network.

### DIFF
--- a/cmd/imageserver/main.go
+++ b/cmd/imageserver/main.go
@@ -7,6 +7,7 @@ import (
 	imageserverRpcd "github.com/Symantec/Dominator/imageserver/rpcd"
 	"github.com/Symantec/Dominator/imageserver/scanner"
 	"github.com/Symantec/Dominator/lib/constants"
+	"github.com/Symantec/Dominator/lib/log/debuglogger"
 	"github.com/Symantec/Dominator/lib/logbuf"
 	"github.com/Symantec/Dominator/lib/objectserver/filesystem"
 	"github.com/Symantec/Dominator/lib/srpc/setupserver"
@@ -84,7 +85,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	objSrvRpcHtmlWriter := objectserverRpcd.Setup(objSrv, logger)
+	objSrvRpcHtmlWriter := objectserverRpcd.Setup(objSrv, imageServerAddress,
+		debuglogger.New(logger))
 	httpd.AddHtmlWriter(imdb)
 	httpd.AddHtmlWriter(&imageObjectServersType{imdb, objSrv})
 	httpd.AddHtmlWriter(imgSrvRpcHtmlWriter)

--- a/cmd/objecttool/addObjects.go
+++ b/cmd/objecttool/addObjects.go
@@ -12,7 +12,7 @@ import (
 func addObjectsSubcommand(objSrv objectserver.ObjectServer, args []string) {
 	if err := addObjects(fmt.Sprintf("%s:%d",
 		*objectServerHostname, *objectServerPortNum), args); err != nil {
-		fmt.Fprintf(os.Stderr, "Error adding obnects hash\t%s\n", err)
+		fmt.Fprintf(os.Stderr, "Error adding objects hash: %s\n", err)
 		os.Exit(2)
 	}
 	os.Exit(0)

--- a/imageserver/client/addImage.go
+++ b/imageserver/client/addImage.go
@@ -11,3 +11,9 @@ func addImage(client *srpc.Client, name string, img *image.Image) error {
 	var reply imageserver.AddImageResponse
 	return client.RequestReply("ImageServer.AddImage", request, &reply)
 }
+
+func addImageTrusted(client *srpc.Client, name string, img *image.Image) error {
+	request := imageserver.AddImageRequest{name, img}
+	var reply imageserver.AddImageResponse
+	return client.RequestReply("ImageServer.AddImageTrusted", request, &reply)
+}

--- a/imageserver/client/api.go
+++ b/imageserver/client/api.go
@@ -11,6 +11,10 @@ func AddImage(client *srpc.Client, name string, img *image.Image) error {
 	return addImage(client, name, img)
 }
 
+func AddImageTrusted(client *srpc.Client, name string, img *image.Image) error {
+	return addImageTrusted(client, name, img)
+}
+
 func CheckImage(client *srpc.Client, name string) (bool, error) {
 	return checkImage(client, name)
 }

--- a/imageserver/rpcd/api.go
+++ b/imageserver/rpcd/api.go
@@ -1,17 +1,27 @@
 package rpcd
 
 import (
+	"errors"
+	"flag"
 	"github.com/Symantec/Dominator/imageserver/scanner"
+	"github.com/Symantec/Dominator/lib/log"
+	"github.com/Symantec/Dominator/lib/objectserver"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"io"
-	"log"
 	"sync"
+)
+
+var (
+	archiveExpiringImages = flag.Bool("archiveExpiringImages", false,
+		"If true, replicate expiring images when in archive mode")
+	archiveMode = flag.Bool("archiveMode", false,
+		"If true, disable delete operations and require update server")
 )
 
 type srpcType struct {
 	imageDataBase             *scanner.ImageDataBase
 	replicationMaster         string
-	logger                    *log.Logger
+	logger                    log.Logger
 	numReplicationClientsLock sync.RWMutex // Protect numReplicationClients.
 	numReplicationClients     uint
 }
@@ -26,11 +36,20 @@ var replicationMessage = "cannot make changes while under replication control" +
 	", go to master: "
 
 func Setup(imdb *scanner.ImageDataBase, replicationMaster string,
-	lg *log.Logger) *htmlWriter {
-	srpcObj := srpcType{
+	objSrv objectserver.FullObjectServer,
+	logger log.Logger) (*htmlWriter, error) {
+	if *archiveMode && replicationMaster == "" {
+		return nil, errors.New("replication master required in archive mode")
+	}
+	srpcObj := &srpcType{
 		imageDataBase:     imdb,
 		replicationMaster: replicationMaster,
-		logger:            lg}
-	srpc.RegisterName("ImageServer", &srpcObj)
-	return (*htmlWriter)(&srpcObj)
+		logger:            logger,
+	}
+	srpc.RegisterName("ImageServer", srpcObj)
+	if replicationMaster != "" {
+		go replicator(replicationMaster, imdb, objSrv, *archiveMode, logger)
+	}
+
+	return (*htmlWriter)(srpcObj), nil
 }

--- a/imageserver/scanner/load.go
+++ b/imageserver/scanner/load.go
@@ -76,6 +76,9 @@ func (imdb *ImageDataBase) scanDirectory(dirname string,
 	}
 	names, err := file.Readdirnames(-1)
 	file.Close()
+	if err != nil {
+		return err
+	}
 	for _, name := range names {
 		if len(name) > 0 && name[0] == '.' {
 			continue // Skip hidden paths.

--- a/lib/errors/api.go
+++ b/lib/errors/api.go
@@ -1,0 +1,17 @@
+package errors
+
+import "errors"
+
+func New(text string) error {
+	if text == "" {
+		return nil
+	}
+	return errors.New(text)
+}
+
+func ErrorToString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/lib/objectserver/api.go
+++ b/lib/objectserver/api.go
@@ -30,6 +30,14 @@ type ObjectServer interface {
 	GetObjects(hashes []hash.Hash) (ObjectsReader, error)
 }
 
+type StashingObjectServer interface {
+	CommitObject(hash.Hash) error
+	DeleteStashedObject(hashVal hash.Hash) error
+	ObjectServer
+	StashOrVerifyObject(io.Reader, uint64, *hash.Hash) (
+		hash.Hash, []byte, error)
+}
+
 func GetObject(objSrv ObjectServer, hashVal hash.Hash) (
 	uint64, io.ReadCloser, error) {
 	return getObject(objSrv, hashVal)

--- a/lib/objectserver/client/addObject.go
+++ b/lib/objectserver/client/addObject.go
@@ -46,8 +46,8 @@ func (objClient *ObjectClient) addObject(reader io.Reader, length uint64,
 	if err := decoder.Decode(&reply); err != nil {
 		return reply.Hash, false, err
 	}
-	if reply.Error != nil {
-		return reply.Hash, false, err
+	if reply.ErrorString != "" {
+		return reply.Hash, false, errors.New(reply.ErrorString)
 	}
 	if expectedHash != nil && *expectedHash != reply.Hash {
 		return reply.Hash, false, errors.New(fmt.Sprintf(

--- a/lib/objectserver/client/api.go
+++ b/lib/objectserver/client/api.go
@@ -82,6 +82,10 @@ func (objQ *ObjectAdderQueue) Add(reader io.Reader, length uint64) (
 	return objQ.add(reader, length)
 }
 
+func (objQ *ObjectAdderQueue) AddData(data []byte, hashVal hash.Hash) error {
+	return objQ.addData(data, hashVal)
+}
+
 func (objQ *ObjectAdderQueue) Close() error {
 	return objQ.close()
 }

--- a/lib/objectserver/client/api.go
+++ b/lib/objectserver/client/api.go
@@ -68,9 +68,9 @@ func (or *ObjectsReader) NextObject() (uint64, io.ReadCloser, error) {
 type ObjectAdderQueue struct {
 	conn            *srpc.Conn
 	encoder         *gob.Encoder
-	getResponseChan chan<- bool
+	getResponseChan chan<- struct{}
 	errorChan       <-chan error
-	sendSemaphore   chan bool
+	sendSemaphore   chan struct{}
 }
 
 func NewObjectAdderQueue(client *srpc.Client) (*ObjectAdderQueue, error) {

--- a/lib/objectserver/client/queue.go
+++ b/lib/objectserver/client/queue.go
@@ -3,8 +3,8 @@ package client
 import (
 	"crypto/sha512"
 	"encoding/gob"
-	"errors"
 	"fmt"
+	"github.com/Symantec/Dominator/lib/errors"
 	"github.com/Symantec/Dominator/lib/hash"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"github.com/Symantec/Dominator/proto/objectserver"
@@ -113,7 +113,7 @@ func readResponses(conn *srpc.Conn, getResponseChan <-chan bool,
 		var reply objectserver.AddObjectResponse
 		err := decoder.Decode(&reply)
 		if err == nil {
-			err = reply.Error
+			err = errors.New(reply.ErrorString)
 		}
 		errorChan <- err
 		if err != nil {

--- a/lib/objectserver/filesystem/api.go
+++ b/lib/objectserver/filesystem/api.go
@@ -20,6 +20,12 @@ func NewObjectServer(baseDir string, logger log.Logger) (
 	return newObjectServer(baseDir, logger)
 }
 
+// AddObject will add an object. Object data are read from reader (length bytes
+// are read). The object hash is computed and compared with expectedHash if not
+// nil. The following are returned:
+//   computed hash value
+//   a boolean which is true if the object is new
+//   an error or nil if no error.
 func (objSrv *ObjectServer) AddObject(reader io.Reader, length uint64,
 	expectedHash *hash.Hash) (hash.Hash, bool, error) {
 	return objSrv.addObject(reader, length, expectedHash)
@@ -29,8 +35,17 @@ func (objSrv *ObjectServer) CheckObjects(hashes []hash.Hash) ([]uint64, error) {
 	return objSrv.checkObjects(hashes)
 }
 
+// CommitObject will commit (add) a previously stashed object.
+func (objSrv *ObjectServer) CommitObject(hashVal hash.Hash) error {
+	return objSrv.commitObject(hashVal)
+}
+
 func (objSrv *ObjectServer) DeleteObject(hashVal hash.Hash) error {
 	return objSrv.deleteObject(hashVal)
+}
+
+func (objSrv *ObjectServer) DeleteStashedObject(hashVal hash.Hash) error {
+	return objSrv.deleteStashedObject(hashVal)
 }
 
 func (objSrv *ObjectServer) GetObject(hashVal hash.Hash) (
@@ -55,6 +70,18 @@ func (objSrv *ObjectServer) NumObjects() uint64 {
 	objSrv.rwLock.RLock()
 	defer objSrv.rwLock.RUnlock()
 	return uint64(len(objSrv.sizesMap))
+}
+
+// StashOrVerifyObject will stash an object if it is new or it will verify if it
+// already exists. Object data are read from reader (length bytes are read). The
+// object hash is computed and compared with expectedHash if not nil.
+// The following are returned:
+//   computed hash value
+//   the object data if the object is new, otherwise nil
+//   an error or nil if no error.
+func (objSrv *ObjectServer) StashOrVerifyObject(reader io.Reader,
+	length uint64, expectedHash *hash.Hash) (hash.Hash, []byte, error) {
+	return objSrv.stashOrVerifyObject(reader, length, expectedHash)
 }
 
 type ObjectsReader struct {

--- a/lib/objectserver/filesystem/new.go
+++ b/lib/objectserver/filesystem/new.go
@@ -64,6 +64,9 @@ func scanDirectory(objSrv *ObjectServer, baseDir string, subpath string,
 		return err
 	}
 	for _, name := range names {
+		if len(name) > 0 && name[0] == '.' {
+			continue // Skip hidden paths.
+		}
 		fullPathName := path.Join(myPathName, name)
 		fi, err := os.Lstat(fullPathName)
 		if err != nil {

--- a/lib/objectserver/filesystem/stash.go
+++ b/lib/objectserver/filesystem/stash.go
@@ -19,6 +19,9 @@ func (objSrv *ObjectServer) commitObject(hashVal hash.Hash) error {
 	stashFilename := path.Join(objSrv.baseDir, stashDirectory, hashName)
 	fi, err := os.Lstat(stashFilename)
 	if err != nil {
+		if length, _ := objSrv.checkObject(hashVal); length > 0 {
+			return nil // Previously committed: return success.
+		}
 		return err
 	}
 	if !fi.Mode().IsRegular() {

--- a/lib/objectserver/filesystem/stash.go
+++ b/lib/objectserver/filesystem/stash.go
@@ -55,9 +55,12 @@ func (objSrv *ObjectServer) stashOrVerifyObject(reader io.Reader,
 	hashName := objectcache.HashToFilename(hashVal)
 	filename := path.Join(objSrv.baseDir, hashName)
 	// Check for existing object and collision.
-	if isNew, err := addOrCompare(hashVal, data, filename); err != nil {
+	if length, err := objSrv.checkObject(hashVal); err != nil {
 		return hashVal, nil, err
-	} else if !isNew {
+	} else if length > 0 {
+		if err := collisionCheck(data, filename, int64(length)); err != nil {
+			return hashVal, nil, err
+		}
 		return hashVal, nil, nil
 	}
 	// Check for existing stashed object and collision.

--- a/lib/objectserver/filesystem/stash.go
+++ b/lib/objectserver/filesystem/stash.go
@@ -1,0 +1,70 @@
+package filesystem
+
+import (
+	"errors"
+	"github.com/Symantec/Dominator/lib/fsutil"
+	"github.com/Symantec/Dominator/lib/hash"
+	"github.com/Symantec/Dominator/lib/objectcache"
+	"io"
+	"os"
+	"path"
+	"syscall"
+)
+
+var stashDirectory string = ".stash"
+
+func (objSrv *ObjectServer) commitObject(hashVal hash.Hash) error {
+	hashName := objectcache.HashToFilename(hashVal)
+	filename := path.Join(objSrv.baseDir, hashName)
+	stashFilename := path.Join(objSrv.baseDir, stashDirectory, hashName)
+	fi, err := os.Lstat(stashFilename)
+	if err != nil {
+		return err
+	}
+	if !fi.Mode().IsRegular() {
+		fsutil.ForceRemove(stashFilename)
+		return errors.New("Existing non-file: " + stashFilename)
+	}
+	if err = os.MkdirAll(path.Dir(filename), syscall.S_IRWXU); err != nil {
+		return err
+	}
+	objSrv.rwLock.Lock()
+	defer objSrv.rwLock.Unlock()
+	if _, ok := objSrv.sizesMap[hashVal]; ok {
+		fsutil.ForceRemove(stashFilename)
+		return nil
+	} else {
+		objSrv.sizesMap[hashVal] = uint64(fi.Size())
+		return os.Rename(stashFilename, filename)
+	}
+}
+
+func (objSrv *ObjectServer) deleteStashedObject(hashVal hash.Hash) error {
+	filename := path.Join(objSrv.baseDir, stashDirectory,
+		objectcache.HashToFilename(hashVal))
+	return os.Remove(filename)
+}
+
+func (objSrv *ObjectServer) stashOrVerifyObject(reader io.Reader,
+	length uint64, expectedHash *hash.Hash) (hash.Hash, []byte, error) {
+	hashVal, data, err := objectcache.ReadObject(reader, length, expectedHash)
+	if err != nil {
+		return hashVal, nil, err
+	}
+	length = uint64(len(data))
+	hashName := objectcache.HashToFilename(hashVal)
+	filename := path.Join(objSrv.baseDir, hashName)
+	// Check for existing object and collision.
+	if isNew, err := addOrCompare(hashVal, data, filename); err != nil {
+		return hashVal, nil, err
+	} else if !isNew {
+		return hashVal, nil, nil
+	}
+	// Check for existing stashed object and collision.
+	stashFilename := path.Join(objSrv.baseDir, stashDirectory, hashName)
+	if _, err := addOrCompare(hashVal, data, stashFilename); err != nil {
+		return hashVal, nil, err
+	} else {
+		return hashVal, data, nil
+	}
+}

--- a/lib/queue/api.go
+++ b/lib/queue/api.go
@@ -1,0 +1,21 @@
+package queue
+
+// NewDataQueue creates a pair of channels (a send-only channel and a
+// receive-only channel) which form a queue. Arbitrary data may be sent via the
+// queue. The send-only channel is always available for sending. Data are stored
+// in an internal buffer until they are dequeued by reading from the
+// receive-only channel. If the send-only channel is closed the receive-only
+// channel will be closed after all data are consumed.
+func NewDataQueue() (chan<- interface{}, <-chan interface{}) {
+	return newDataQueue()
+}
+
+// NewEventQueue creates a pair of channels (a send-only channel and a
+// receive-only channel) which form a queue. Events (empty structures) may be
+// sent via the queue. The send-only channel is always available for sending.
+// An internal count of events received but not consumed is maintained. If the
+// send-only channel is closed the receive-only channel will be closed after all
+// events are consumed.
+func NewEventQueue() (chan<- struct{}, <-chan struct{}) {
+	return newEventQueue()
+}

--- a/lib/queue/dataQueue.go
+++ b/lib/queue/dataQueue.go
@@ -1,0 +1,39 @@
+package queue
+
+import "container/list"
+
+func newDataQueue() (chan<- interface{}, <-chan interface{}) {
+	send := make(chan interface{}, 1)
+	receive := make(chan interface{}, 1)
+	go manageDataQueue(send, receive)
+	return send, receive
+}
+
+func manageDataQueue(send <-chan interface{}, receive chan<- interface{}) {
+	queue := list.New()
+	for {
+		if front := queue.Front(); front == nil {
+			if send == nil {
+				close(receive)
+				return
+			}
+			value, ok := <-send
+			if !ok {
+				close(receive)
+				return
+			}
+			queue.PushBack(value)
+		} else {
+			select {
+			case receive <- front.Value:
+				queue.Remove(front)
+			case value, ok := <-send:
+				if ok {
+					queue.PushBack(value)
+				} else {
+					send = nil
+				}
+			}
+		}
+	}
+}

--- a/lib/queue/eventQueue.go
+++ b/lib/queue/eventQueue.go
@@ -1,0 +1,37 @@
+package queue
+
+func newEventQueue() (chan<- struct{}, <-chan struct{}) {
+	send := make(chan struct{}, 1)
+	receive := make(chan struct{}, 1)
+	go manageEventQueue(send, receive)
+	return send, receive
+}
+
+func manageEventQueue(send <-chan struct{}, receive chan<- struct{}) {
+	numInQueue := 0
+	for {
+		if numInQueue < 1 {
+			if send == nil {
+				close(receive)
+				return
+			}
+			_, ok := <-send
+			if !ok {
+				close(receive)
+				return
+			}
+			numInQueue++
+		} else {
+			select {
+			case receive <- struct{}{}:
+				numInQueue--
+			case _, ok := <-send:
+				if ok {
+					numInQueue++
+				} else {
+					send = nil
+				}
+			}
+		}
+	}
+}

--- a/objectserver/rpcd/addObjects.go
+++ b/objectserver/rpcd/addObjects.go
@@ -8,5 +8,9 @@ import (
 
 func (t *srpcType) AddObjects(conn *srpc.Conn) error {
 	defer runtime.GC() // An opportune time to take out the garbage.
-	return lib.AddObjects(conn, t.objectServer, t.logger)
+	if t.replicationMaster == "" {
+		return lib.AddObjects(conn, t.objectServer, t.logger)
+	}
+	return lib.AddObjectsWithMaster(conn, t.objectServer, t.replicationMaster,
+		t.logger)
 }

--- a/objectserver/rpcd/api.go
+++ b/objectserver/rpcd/api.go
@@ -1,18 +1,19 @@
 package rpcd
 
 import (
+	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/Dominator/lib/objectserver"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"github.com/Symantec/tricorder/go/tricorder"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"io"
-	"log"
 )
 
 type srpcType struct {
-	objectServer objectserver.ObjectServer
-	getSemaphore chan bool
-	logger       *log.Logger
+	objectServer      objectserver.StashingObjectServer
+	replicationMaster string
+	getSemaphore      chan bool
+	logger            log.DebugLogger
 }
 
 type htmlWriter struct {
@@ -23,9 +24,10 @@ func (hw *htmlWriter) WriteHtml(writer io.Writer) {
 	hw.writeHtml(writer)
 }
 
-func Setup(objSrv objectserver.ObjectServer, logger *log.Logger) *htmlWriter {
+func Setup(objSrv objectserver.StashingObjectServer, replicationMaster string,
+	logger log.DebugLogger) *htmlWriter {
 	getSemaphore := make(chan bool, 100)
-	srpcObj := &srpcType{objSrv, getSemaphore, logger}
+	srpcObj := &srpcType{objSrv, replicationMaster, getSemaphore, logger}
 	srpc.RegisterName("ObjectServer", srpcObj)
 	tricorder.RegisterMetric("/get-requests",
 		func() uint { return uint(len(getSemaphore)) },

--- a/objectserver/rpcd/lib/addObjects.go
+++ b/objectserver/rpcd/lib/addObjects.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/gob"
+	"github.com/Symantec/Dominator/lib/errors"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"github.com/Symantec/Dominator/proto/objectserver"
 	"io"
@@ -26,17 +27,19 @@ func addObjects(conn *srpc.Conn, adder ObjectAdder, logger *log.Logger) error {
 		if request.Length < 1 {
 			break
 		}
-		response.Hash, response.Added, response.Error =
+		var err error
+		response.Hash, response.Added, err =
 			adder.AddObject(conn, request.Length, request.ExpectedHash)
+		response.ErrorString = errors.ErrorToString(err)
 		if response.Added {
 			numAdded++
 		}
 		if err := encoder.Encode(response); err != nil {
 			return err
 		}
-		if response.Error != nil {
+		if response.ErrorString != "" {
 			logger.Printf("AddObjects(): failed, %d of %d are new objects %s",
-				numAdded, numObj, response.Error.Error())
+				numAdded, numObj, response.ErrorString)
 			return nil
 		}
 	}

--- a/objectserver/rpcd/lib/addObjects.go
+++ b/objectserver/rpcd/lib/addObjects.go
@@ -11,6 +11,7 @@ import (
 
 func addObjects(conn *srpc.Conn, adder ObjectAdder, logger log.Logger) error {
 	defer conn.Flush()
+	logger.Printf("AddObjects(%s) starting\n", conn.RemoteAddr())
 	decoder := gob.NewDecoder(conn)
 	encoder := gob.NewEncoder(conn)
 	numAdded := 0

--- a/objectserver/rpcd/lib/addObjects.go
+++ b/objectserver/rpcd/lib/addObjects.go
@@ -3,13 +3,13 @@ package lib
 import (
 	"encoding/gob"
 	"github.com/Symantec/Dominator/lib/errors"
+	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"github.com/Symantec/Dominator/proto/objectserver"
 	"io"
-	"log"
 )
 
-func addObjects(conn *srpc.Conn, adder ObjectAdder, logger *log.Logger) error {
+func addObjects(conn *srpc.Conn, adder ObjectAdder, logger log.Logger) error {
 	defer conn.Flush()
 	decoder := gob.NewDecoder(conn)
 	encoder := gob.NewEncoder(conn)

--- a/objectserver/rpcd/lib/addObjectsWithMaster.go
+++ b/objectserver/rpcd/lib/addObjectsWithMaster.go
@@ -1,0 +1,373 @@
+package lib
+
+import (
+	"container/list"
+	"encoding/gob"
+	"fmt"
+	"github.com/Symantec/Dominator/lib/errors"
+	"github.com/Symantec/Dominator/lib/hash"
+	"github.com/Symantec/Dominator/lib/log"
+	"github.com/Symantec/Dominator/lib/objectserver"
+	oclient "github.com/Symantec/Dominator/lib/objectserver/client"
+	"github.com/Symantec/Dominator/lib/srpc"
+	proto "github.com/Symantec/Dominator/proto/objectserver"
+	"io"
+)
+
+func addObjectsWithMaster(conn *srpc.Conn,
+	objSrv objectserver.StashingObjectServer, masterAddress string,
+	logger log.DebugLogger) error {
+	logger.Printf("AddObjectsWithMaster(%s) starting\n", conn.RemoteAddr())
+	defer conn.Flush()
+	decoder := gob.NewDecoder(conn)
+	numAdded := 0
+	numObj := 0
+	outgoingQueueSendChan, outgoingQueueReceiveChan := newOutgoingQueue()
+	errorChan := make(chan error, 1)
+	defer close(outgoingQueueSendChan)
+	go processOutgoingQueue(gob.NewEncoder(conn), outgoingQueueReceiveChan,
+		errorChan, logger)
+	masterQueueSendChan, masterQueueReceiveChan := newMasterQueue()
+	defer close(masterQueueSendChan)
+	masterDrain := make(chan error, 1)
+	masterClient, err := srpc.DialHTTP("tcp", masterAddress, 0)
+	if err != nil {
+		sendError(outgoingQueueSendChan, err)
+		return nil
+	}
+	defer masterClient.Close()
+	var masterConn *srpc.Conn
+	var masterEncoder *gob.Encoder
+	locallyKnownObjects := make([]hash.Hash, 0)
+	// First process the stream of incoming objects, verify or stash+send.
+	for ; ; numObj++ {
+		if len(errorChan) > 0 {
+			break
+		}
+		var request proto.AddObjectRequest
+		var response proto.AddObjectResponse
+		err := decoder.Decode(&request)
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return errors.New("error decoding: " + err.Error())
+		}
+		if request.Length < 1 {
+			break
+		}
+		var data []byte
+		response.Hash, data, err = objSrv.StashOrVerifyObject(conn,
+			request.Length, request.ExpectedHash)
+		if err != nil {
+			sendError(outgoingQueueSendChan, err)
+			break
+		}
+		entry := make(chan proto.AddObjectResponse, 1)
+		if data == nil { // Object already exists
+			entry <- response
+			outgoingQueueSendChan <- entry
+			locallyKnownObjects = append(locallyKnownObjects, response.Hash)
+			continue
+		}
+		if masterEncoder == nil {
+			masterConn, err = masterClient.Call("ObjectServer.AddObjects")
+			if err != nil {
+				sendError(outgoingQueueSendChan,
+					errors.New("error calling master: "+masterAddress+": "+
+						err.Error()))
+				break
+			}
+			defer func() {
+				if masterConn != nil {
+					masterConn.Close()
+				}
+			}()
+			go processResponses(gob.NewDecoder(masterConn),
+				masterQueueReceiveChan, masterDrain, objSrv)
+			masterEncoder = gob.NewEncoder(masterConn)
+			logger.Debugln(0,
+				"AddObjectsWithMaster(): called ObjectServer.AddObjects for master")
+		}
+		err = sendRequest(masterConn, masterEncoder, data, response.Hash)
+		if err != nil {
+			sendError(outgoingQueueSendChan, err)
+			break
+		}
+		masterQueueSendChan <- entry
+		outgoingQueueSendChan <- entry
+		numAdded++
+	}
+	logger.Debugln(0, "AddObjectsWithMaster(): Read all objects from client")
+	if masterEncoder != nil {
+		err := sendRequest(masterConn, masterEncoder, nil, hash.Hash{})
+		if err != nil {
+			sendError(outgoingQueueSendChan, err)
+			logger.Printf(
+				"AddObjectsWithMaster(): failed, %d of %d so far are new objects: %s",
+				numAdded, numObj, err)
+			return nil
+		}
+		masterQueueSendChan <- nil
+		err = <-masterDrain
+		masterConn.Close()
+		masterConn = nil
+		if err != nil {
+			logger.Printf(
+				"AddObjectsWithMaster(): failed, %d of %d so far are new objects: %s",
+				numAdded, numObj, err)
+			return nil
+		}
+	}
+	// Check for objects missing on the master.
+	err = sendMissingObjects(objSrv, masterClient, locallyKnownObjects, logger)
+	if err != nil {
+		sendError(outgoingQueueSendChan, err)
+		err = <-errorChan
+		logger.Printf(
+			"AddObjectsWithMaster(): failed, %d of %d so far are new objects: %s",
+			numAdded, numObj, err)
+		return nil
+	}
+	logger.Debugln(0, "Sending flush request for outgoing queue")
+	outgoingQueueSendChan <- nil
+	logger.Debugln(0, "Sent flush request for outgoing queue")
+	if err := <-errorChan; err != nil {
+		logger.Printf(
+			"AddObjectsWithMaster(): failed, %d of %d so far are new objects: %s",
+			numAdded, numObj, err)
+	} else {
+		logger.Printf("AddObjectsWithMaster(): %d of %d are new objects",
+			numAdded, numObj)
+	}
+	return nil
+}
+
+func processOutgoingQueue(encoder *gob.Encoder,
+	queue <-chan <-chan proto.AddObjectResponse, errorChan chan<- error,
+	logger log.DebugLogger) {
+	// Hold back one response until flush entry. This ensures the client will
+	// read an error message before seeing last "OK".
+	var previousResponse *proto.AddObjectResponse
+	for entry := range queue {
+		var response proto.AddObjectResponse
+		if entry != nil {
+			response = <-entry
+			if response.ErrorString != "" { // Preempt previous response.
+				previousResponse = &response
+			}
+		}
+		if previousResponse != nil {
+			if err := encoder.Encode(*previousResponse); err != nil {
+				err = errors.New("error encoding: " + err.Error())
+				errorChan <- err
+				break
+			}
+			if err := errors.New(previousResponse.ErrorString); err != nil {
+				errorChan <- err
+				break
+			}
+		}
+		if entry == nil {
+			errorChan <- nil
+			break
+		}
+		previousResponse = &response
+	}
+	logger.Debugln(0, "Draining outgoing queue")
+	for range queue { // Drain the queue.
+	}
+}
+
+func processResponses(decoder *gob.Decoder,
+	queue <-chan chan<- proto.AddObjectResponse, completed chan<- error,
+	objSrv objectserver.StashingObjectServer) {
+	var err error
+	for entry := range queue {
+		if entry == nil {
+			break
+		}
+		var reply proto.AddObjectResponse
+		if err = decoder.Decode(&reply); err != nil {
+			reply.ErrorString = "error decoding: " + err.Error()
+			entry <- reply
+			break
+		}
+		if reply.ErrorString == "" {
+			if err = objSrv.CommitObject(reply.Hash); err != nil {
+				reply.ErrorString = "commit error: " + err.Error()
+				entry <- reply
+				break
+			}
+		}
+		entry <- reply
+	}
+	completed <- err
+	for range queue { // Drain the queue.
+	}
+}
+
+func sendRequest(conn *srpc.Conn, encoder *gob.Encoder, data []byte,
+	hashVal hash.Hash) error {
+	request := proto.AddObjectRequest{
+		Length:       uint64(len(data)),
+		ExpectedHash: &hashVal,
+	}
+	if err := encoder.Encode(request); err != nil {
+		return err
+	}
+	if len(data) > 0 {
+		_, err := conn.Write(data)
+		return err
+	}
+	return conn.Flush()
+}
+
+func sendError(queue chan<- <-chan proto.AddObjectResponse, err error) {
+	entry := make(chan proto.AddObjectResponse, 1)
+	entry <- proto.AddObjectResponse{ErrorString: err.Error()}
+	queue <- entry
+}
+
+func sendMissingObjects(objSrv objectserver.StashingObjectServer,
+	masterClient *srpc.Client, locallyKnownObjects []hash.Hash,
+	logger log.DebugLogger) error {
+	if len(locallyKnownObjects) < 1 {
+		return nil
+	}
+	logger.Debugf(0,
+		"Checking %d locally known objects for presence on master\n",
+		len(locallyKnownObjects))
+	objClient := oclient.AttachObjectClient(masterClient)
+	lengths, err := objClient.CheckObjects(locallyKnownObjects)
+	objClient.Close()
+	if err != nil {
+		return fmt.Errorf("error checking master for known objects: %s", err)
+	}
+	allObjectsKnownOnMaster := true
+	for _, lengthOnMaster := range lengths {
+		if lengthOnMaster < 1 {
+			allObjectsKnownOnMaster = false
+			break
+		}
+	}
+	if allObjectsKnownOnMaster {
+		return nil
+	}
+	adderQueue, err := oclient.NewObjectAdderQueue(masterClient)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if adderQueue != nil {
+			adderQueue.Close()
+		}
+	}()
+	numSent := 0
+	for index, lengthOnMaster := range lengths {
+		if lengthOnMaster > 0 {
+			continue
+		}
+		hashVal := locallyKnownObjects[index]
+		length, reader, err := objectserver.GetObject(objSrv, hashVal)
+		if err != nil {
+			return err
+		}
+		data := make([]byte, length)
+		nRead, err := io.ReadFull(reader, data)
+		reader.Close()
+		if err != nil {
+			return err
+		}
+		if uint64(nRead) != length {
+			return fmt.Errorf(
+				"failed to read file data, wanted: %d, got: %d bytes",
+				length, nRead)
+		}
+		if err := adderQueue.AddData(data, hashVal); err != nil {
+			return err
+		}
+		numSent++
+	}
+	err = adderQueue.Close()
+	adderQueue = nil
+	logger.Printf("AddObjectsWithMaster() Sent: %d of %d locally known objects\n",
+		numSent, len(locallyKnownObjects))
+	return err
+}
+
+func newOutgoingQueue() (chan<- <-chan proto.AddObjectResponse,
+	<-chan <-chan proto.AddObjectResponse) {
+	send := make(chan (<-chan proto.AddObjectResponse), 1)
+	receive := make(chan (<-chan proto.AddObjectResponse), 1)
+	go manageOutgoingQueue(send, receive)
+	return send, receive
+}
+
+func manageOutgoingQueue(send <-chan <-chan proto.AddObjectResponse,
+	receive chan<- <-chan proto.AddObjectResponse) {
+	queue := list.New()
+	for {
+		if front := queue.Front(); front == nil {
+			if send == nil {
+				close(receive)
+				return
+			}
+			response, ok := <-send
+			if !ok {
+				close(receive)
+				return
+			}
+			queue.PushBack(response)
+		} else {
+			select {
+			case receive <- front.Value.(<-chan proto.AddObjectResponse):
+				queue.Remove(front)
+			case response, ok := <-send:
+				if ok {
+					queue.PushBack(response)
+				} else {
+					send = nil
+				}
+			}
+		}
+	}
+}
+
+func newMasterQueue() (chan<- chan<- proto.AddObjectResponse,
+	<-chan chan<- proto.AddObjectResponse) {
+	send := make(chan chan<- proto.AddObjectResponse, 1)
+	receive := make(chan chan<- proto.AddObjectResponse, 1)
+	go manageMasterQueue(send, receive)
+	return send, receive
+}
+
+func manageMasterQueue(send <-chan chan<- proto.AddObjectResponse,
+	receive chan<- chan<- proto.AddObjectResponse) {
+	queue := list.New()
+	for {
+		if front := queue.Front(); front == nil {
+			if send == nil {
+				close(receive)
+				return
+			}
+			response, ok := <-send
+			if !ok {
+				close(receive)
+				return
+			}
+			queue.PushBack(response)
+		} else {
+			select {
+			case receive <- front.Value.(chan<- proto.AddObjectResponse):
+				queue.Remove(front)
+			case response, ok := <-send:
+				if ok {
+					queue.PushBack(response)
+				} else {
+					send = nil
+				}
+			}
+		}
+	}
+}

--- a/objectserver/rpcd/lib/api.go
+++ b/objectserver/rpcd/lib/api.go
@@ -2,9 +2,10 @@ package lib
 
 import (
 	"github.com/Symantec/Dominator/lib/hash"
+	"github.com/Symantec/Dominator/lib/log"
+	"github.com/Symantec/Dominator/lib/objectserver"
 	"github.com/Symantec/Dominator/lib/srpc"
 	"io"
-	"log"
 )
 
 type ObjectAdder interface {
@@ -12,6 +13,12 @@ type ObjectAdder interface {
 		hash.Hash, bool, error)
 }
 
-func AddObjects(conn *srpc.Conn, adder ObjectAdder, logger *log.Logger) error {
+func AddObjects(conn *srpc.Conn, adder ObjectAdder, logger log.Logger) error {
 	return addObjects(conn, adder, logger)
+}
+
+func AddObjectsWithMaster(conn *srpc.Conn,
+	objSrv objectserver.StashingObjectServer, masterAddress string,
+	logger log.DebugLogger) error {
+	return addObjectsWithMaster(conn, objSrv, masterAddress, logger)
 }

--- a/proto/objectserver/messages.go
+++ b/proto/objectserver/messages.go
@@ -15,9 +15,9 @@ type AddObjectRequest struct {
 } // Object data are streamed afterwards.
 
 type AddObjectResponse struct {
-	Error error
-	Hash  hash.Hash
-	Added bool // If true: object was added, else object already existed.
+	ErrorString string
+	Hash        hash.Hash
+	Added       bool // If true: object was added, else object already existed.
 }
 
 type CheckObjectsRequest struct {


### PR DESCRIPTION
Description of algorithm: client (imagetool) will upload objects to the nearby objectserver which stages them for verification, sending them to it's master. That master will stage objects for verification and send to it's master, until the root master, which verifies and returns OK back down the chain. This has the nice property that there are no duplicate transfers of objects and it's conceptually straightfoward. This keeps the protocol for clients the same.

Use the same stash and forward scheme for images as well. There is a little added latency since objects and images have to be fully read before being forwarded upwards and thus before the operations return. However, there are no duplicate transfers and global consistency is guaranteed.