### PR TITLE
Fixes to work on ARM.

### DIFF
--- a/lib/filesystem/scanner/walk.go
+++ b/lib/filesystem/scanner/walk.go
@@ -4,18 +4,17 @@ import (
 	"crypto/sha512"
 	"errors"
 	"fmt"
+	"github.com/Symantec/Dominator/lib/filesystem"
+	"github.com/Symantec/Dominator/lib/filter"
+	"github.com/Symantec/Dominator/lib/fsrateio"
+	"github.com/Symantec/Dominator/lib/hash"
+	"github.com/Symantec/Dominator/lib/wsyscall"
 	"io"
 	"os"
 	"path"
 	"runtime"
 	"sort"
 	"syscall"
-
-	"github.com/Symantec/Dominator/lib/filesystem"
-	"github.com/Symantec/Dominator/lib/filter"
-	"github.com/Symantec/Dominator/lib/fsrateio"
-	"github.com/Symantec/Dominator/lib/hash"
-	"github.com/Symantec/Dominator/lib/wsyscall"
 )
 
 var myCountGC int

--- a/lib/filesystem/scanner/walk.go
+++ b/lib/filesystem/scanner/walk.go
@@ -4,17 +4,18 @@ import (
 	"crypto/sha512"
 	"errors"
 	"fmt"
-	"github.com/Symantec/Dominator/lib/filesystem"
-	"github.com/Symantec/Dominator/lib/filter"
-	"github.com/Symantec/Dominator/lib/fsrateio"
-	"github.com/Symantec/Dominator/lib/hash"
-	"github.com/Symantec/Dominator/lib/wsyscall"
 	"io"
 	"os"
 	"path"
 	"runtime"
 	"sort"
 	"syscall"
+
+	"github.com/Symantec/Dominator/lib/filesystem"
+	"github.com/Symantec/Dominator/lib/filter"
+	"github.com/Symantec/Dominator/lib/fsrateio"
+	"github.com/Symantec/Dominator/lib/hash"
+	"github.com/Symantec/Dominator/lib/wsyscall"
 )
 
 var myCountGC int
@@ -32,7 +33,7 @@ func makeRegularInode(stat *wsyscall.Stat_t) *filesystem.RegularInode {
 	inode.Mode = filesystem.FileMode(stat.Mode)
 	inode.Uid = stat.Uid
 	inode.Gid = stat.Gid
-	inode.MtimeSeconds = stat.Mtim.Sec
+	inode.MtimeSeconds = int64(stat.Mtim.Sec)
 	inode.MtimeNanoSeconds = int32(stat.Mtim.Nsec)
 	inode.Size = uint64(stat.Size)
 	return &inode
@@ -50,7 +51,7 @@ func makeSpecialInode(stat *wsyscall.Stat_t) *filesystem.SpecialInode {
 	inode.Mode = filesystem.FileMode(stat.Mode)
 	inode.Uid = stat.Uid
 	inode.Gid = stat.Gid
-	inode.MtimeSeconds = stat.Mtim.Sec
+	inode.MtimeSeconds = int64(stat.Mtim.Sec)
 	inode.MtimeNanoSeconds = int32(stat.Mtim.Nsec)
 	inode.Rdev = stat.Rdev
 	return &inode

--- a/lib/fsbench/fsbench.go
+++ b/lib/fsbench/fsbench.go
@@ -1,13 +1,12 @@
 package fsbench
 
 import (
+	"github.com/Symantec/Dominator/lib/wsyscall"
 	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
 	"time"
-
-	"github.com/Symantec/Dominator/lib/wsyscall"
 )
 
 const (

--- a/lib/fsbench/fsbench.go
+++ b/lib/fsbench/fsbench.go
@@ -1,23 +1,23 @@
 package fsbench
 
 import (
-	"github.com/Symantec/Dominator/lib/wsyscall"
 	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
 	"time"
+
+	"github.com/Symantec/Dominator/lib/wsyscall"
 )
 
 const (
-	O_DIRECT    = 00040000
 	BUFLEN      = 1024 * 1024
 	MAX_TO_READ = 1024 * 1024 * 128
 )
 
 func openDirect(name string, flag int, perm os.FileMode) (file *os.File,
 	err error) {
-	return os.OpenFile(name, flag|O_DIRECT, perm)
+	return os.OpenFile(name, flag|syscall.O_DIRECT, perm)
 }
 
 func GetDevnumForFile(name string) (devnum uint64, err error) {

--- a/user-guide/getting-started.md
+++ b/user-guide/getting-started.md
@@ -50,6 +50,7 @@ following commands:
 git clone https://github.com/Symantec/tricorder.git
 git clone https://github.com/golang/exp.git
 git clone https://github.com/aws/aws-sdk-go.git
+git clone https://gopkg.in/fsnotify.v0
 ```
 
 You can update the local copies of these repositories to the latest version of


### PR DESCRIPTION
I had to make these changes to get Dominator working on Raspberry Pi.

The most significant change is the use of syscall.O_DIRECT rather than hard
coding the constant in the fsbench code. I've only tested this with linux on
arm.

The changes in walk.go fixes a build issue, the changes to the include list are
due to running go import.

I also included a fix to the README.