### PR TITLE
Introduce awsutil.TryLoadCredentialsWithOptions()

### DIFF
--- a/lib/awsutil/accounts.go
+++ b/lib/awsutil/accounts.go
@@ -3,18 +3,17 @@ package awsutil
 import (
 	"bufio"
 	"os"
-	"path"
 	"strings"
 )
 
-func listAccountNames() ([]string, error) {
+func listAccountNames(options *CredentialsOptions) ([]string, error) {
 	var accountNames []string
-	if names, err := listFile("credentials", "aws_access_key_id"); err != nil {
+	if names, err := listFile(options.CredentialsPath, "aws_access_key_id"); err != nil {
 		return nil, err
 	} else {
 		accountNames = append(accountNames, names...)
 	}
-	if names, err := listFile("config", "role_arn"); err != nil {
+	if names, err := listFile(options.ConfigPath, "role_arn"); err != nil {
 		return nil, err
 	} else {
 		accountNames = append(accountNames, names...)
@@ -22,8 +21,7 @@ func listAccountNames() ([]string, error) {
 	return accountNames, nil
 }
 
-func listFile(filename string, identifierKeyName string) ([]string, error) {
-	pathname := path.Join(os.Getenv("HOME"), ".aws", filename)
+func listFile(pathname string, identifierKeyName string) ([]string, error) {
 	file, err := os.Open(pathname)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/lib/awsutil/api.go
+++ b/lib/awsutil/api.go
@@ -1,10 +1,19 @@
 package awsutil
 
 import (
+	"flag"
+
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var (
+	awsConfigFile = flag.String(
+		"awsConfigFile", "", "Location of AWS config file")
+	awsCredentialsFile = flag.String(
+		"awsCredentialsFile", "", "Location of AWS credentials file")
 )
 
 func CreateService(awsSession *session.Session, regionName string) *ec2.EC2 {
@@ -14,17 +23,25 @@ func CreateService(awsSession *session.Session, regionName string) *ec2.EC2 {
 func CreateSession(accountProfileName string) (*session.Session, error) {
 	return session.NewSessionWithOptions(session.Options{
 		Profile:           accountProfileName,
-		SharedConfigState: session.SharedConfigEnable})
+		SharedConfigState: session.SharedConfigEnable,
+		SharedConfigFiles: []string{
+			getCredentialsPath(),
+			getConfigPath(),
+		},
+	})
 }
 
 // CredentialsOptions contains options for loading credentials
 type CredentialsOptions struct {
+
 	// The path of the credentials file.
-	// If empty, defaults to ~/.aws/credentials
+	// If empty, defaults to to the same location that the LoadCredentials
+	// function uses.
 	CredentialsPath string
 
 	// The path of the config file.
-	// If empty, defaults to ~/.aws/config
+	// If empty, defaults to the same location that the LoadCredentials
+	// function uses.
 	ConfigPath string
 }
 
@@ -38,8 +55,17 @@ type CredentialsStore struct {
 	accountRegions  map[string][]string         // Key: account name.
 }
 
-// LoadCredentials loads credentials from ~/.aws/credentials and roles from
-// ~/.aws/config which may be used later.
+// LoadCredentials loads credentials from the aws credentials file and roles
+// from the aws config file which may be used later.
+//
+// The location of the credentials file is determined using the following
+// rules from highest to lowest precedence 1) -awsCredentialFile command line
+// parameter. 2) AWS_CREDENTIAL_FILE environment variable.
+// 3) ~/.aws/credentials
+//
+// The location of the config file is determines using the following rules
+// from highest to lowest precedence 2) -awsConfigFile command line parameter
+// 2) AWS_CONFIG_FILE environment variable. 3) ~/.aws/config
 func LoadCredentials() (*CredentialsStore, error) {
 	return loadCredentials()
 }
@@ -51,14 +77,15 @@ func LoadCredentials() (*CredentialsStore, error) {
 // TryLoadCredentials returns nil, nil, err
 func TryLoadCredentials() (
 	store *CredentialsStore, unloadedAccounts map[string]error, err error) {
-	return tryLoadCredentialsWithOptions(kDefaultCredentialsOptions)
+	var options CredentialsOptions
+	return tryLoadCredentialsWithOptions(options.setDefaults())
 }
 
 // TryLoadCredentialsWithOptions works just like TryLoadCredentials but
 // allows caller to specify options for loading the credentials.
-func TryLoadCredentialsWithOptions(config CredentialsOptions) (
+func TryLoadCredentialsWithOptions(options CredentialsOptions) (
 	store *CredentialsStore, unloadedAccounts map[string]error, err error) {
-	return tryLoadCredentialsWithOptions(config.setDefaults())
+	return tryLoadCredentialsWithOptions(options.setDefaults())
 }
 
 // AccountIdToName will return an account name given an account ID.
@@ -143,7 +170,8 @@ func GetLocalRegion() (string, error) {
 }
 
 func ListAccountNames() ([]string, error) {
-	return listAccountNames(kDefaultCredentialsOptions)
+	var options CredentialsOptions
+	return listAccountNames(options.setDefaults())
 }
 
 func ListAccountNamesWithOptions(options CredentialsOptions) ([]string, error) {

--- a/lib/awsutil/api.go
+++ b/lib/awsutil/api.go
@@ -17,6 +17,17 @@ func CreateSession(accountProfileName string) (*session.Session, error) {
 		SharedConfigState: session.SharedConfigEnable})
 }
 
+// CredentialsOptions contains options for loading credentials
+type CredentialsOptions struct {
+	// The path of the credentials file.
+	// If empty, defaults to ~/.aws/credentials
+	CredentialsPath string
+
+	// The path of the config file.
+	// If empty, defaults to ~/.aws/config
+	ConfigPath string
+}
+
 // CredentialsStore records AWS credentials (IAM users and roles) for multiple
 // accounts. The methods are safe to use concurrently.
 type CredentialsStore struct {
@@ -40,7 +51,14 @@ func LoadCredentials() (*CredentialsStore, error) {
 // TryLoadCredentials returns nil, nil, err
 func TryLoadCredentials() (
 	store *CredentialsStore, unloadedAccounts map[string]error, err error) {
-	return tryLoadCredentials()
+	return tryLoadCredentialsWithOptions(kDefaultCredentialsOptions)
+}
+
+// TryLoadCredentialsWithOptions works just like TryLoadCredentials but
+// allows caller to specify options for loading the credentials.
+func TryLoadCredentialsWithOptions(config CredentialsOptions) (
+	store *CredentialsStore, unloadedAccounts map[string]error, err error) {
+	return tryLoadCredentialsWithOptions(config.setDefaults())
 }
 
 // AccountIdToName will return an account name given an account ID.
@@ -125,7 +143,11 @@ func GetLocalRegion() (string, error) {
 }
 
 func ListAccountNames() ([]string, error) {
-	return listAccountNames()
+	return listAccountNames(kDefaultCredentialsOptions)
+}
+
+func ListAccountNamesWithOptions(options CredentialsOptions) ([]string, error) {
+	return listAccountNames(options.setDefaults())
 }
 
 func ListRegions(awsService *ec2.EC2) ([]string, error) {

--- a/lib/awsutil/api.go
+++ b/lib/awsutil/api.go
@@ -11,9 +11,11 @@ import (
 
 var (
 	awsConfigFile = flag.String(
-		"awsConfigFile", "", "Location of AWS config file")
+		"awsConfigFile", getConfigPath(), "Location of AWS config file")
 	awsCredentialsFile = flag.String(
-		"awsCredentialsFile", "", "Location of AWS credentials file")
+		"awsCredentialsFile",
+		getCredentialsPath(),
+		"Location of AWS credentials file")
 )
 
 func CreateService(awsSession *session.Session, regionName string) *ec2.EC2 {
@@ -25,8 +27,8 @@ func CreateSession(accountProfileName string) (*session.Session, error) {
 		Profile:           accountProfileName,
 		SharedConfigState: session.SharedConfigEnable,
 		SharedConfigFiles: []string{
-			getCredentialsPath(),
-			getConfigPath(),
+			*awsCredentialsFile,
+			*awsConfigFile,
 		},
 	})
 }

--- a/lib/awsutil/credentials.go
+++ b/lib/awsutil/credentials.go
@@ -7,6 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"os"
+	"path"
+)
+
+var (
+	kDefaultCredentialsOptions = (&CredentialsOptions{}).setDefaults()
 )
 
 type sessionResult struct {
@@ -17,28 +23,42 @@ type sessionResult struct {
 	err         error
 }
 
-func tryLoadCredentials() (*CredentialsStore, map[string]error, error) {
-	accountNames, err := listAccountNames()
+func (c *CredentialsOptions) setDefaults() *CredentialsOptions {
+	home := os.Getenv("HOME")
+	if c.CredentialsPath == "" {
+		c.CredentialsPath = path.Join(home, ".aws", "credentials")
+	}
+	if c.ConfigPath == "" {
+		c.ConfigPath = path.Join(home, ".aws", "config")
+	}
+	return c
+}
+
+func tryLoadCredentialsWithOptions(
+	options *CredentialsOptions) (*CredentialsStore, map[string]error, error) {
+	accountNames, err := listAccountNames(options)
 	if err != nil {
 		return nil, nil, err
 	}
-	cs, unloadableAccounts := createCredentials(accountNames)
+	cs, unloadableAccounts := createCredentials(accountNames, options)
 	return cs, unloadableAccounts, nil
 }
 
 func loadCredentials() (*CredentialsStore, error) {
-	accountNames, err := listAccountNames()
+	accountNames, err := listAccountNames(kDefaultCredentialsOptions)
 	if err != nil {
 		return nil, err
 	}
-	cs, unloadableAccounts := createCredentials(accountNames)
+	cs, unloadableAccounts := createCredentials(
+		accountNames, kDefaultCredentialsOptions)
 	for _, err := range unloadableAccounts {
 		return nil, err
 	}
 	return cs, nil
 }
 
-func createCredentials(accountNames []string) (
+func createCredentials(
+	accountNames []string, options *CredentialsOptions) (
 	*CredentialsStore, map[string]error) {
 	sort.Strings(accountNames)
 	cs := &CredentialsStore{
@@ -51,7 +71,7 @@ func createCredentials(accountNames []string) (
 	resultsChannel := make(chan sessionResult, len(accountNames))
 	for _, accountName := range accountNames {
 		go func(accountName string) {
-			resultsChannel <- createSession(accountName)
+			resultsChannel <- createSession(accountName, options)
 		}(accountName)
 	}
 	unloadableAccounts := make(map[string]error)
@@ -70,8 +90,16 @@ func createCredentials(accountNames []string) (
 	return cs, unloadableAccounts
 }
 
-func createSession(accountName string) sessionResult {
-	awsSession, err := CreateSession(accountName)
+func createSession(
+	accountName string, options *CredentialsOptions) sessionResult {
+	awsSession, err := session.NewSessionWithOptions(session.Options{
+		Profile:           accountName,
+		SharedConfigState: session.SharedConfigEnable,
+		SharedConfigFiles: []string{
+			options.CredentialsPath,
+			options.ConfigPath,
+		},
+	})
 	if err != nil {
 		return sessionResult{err: err, accountName: accountName}
 	}

--- a/lib/awsutil/credentials.go
+++ b/lib/awsutil/credentials.go
@@ -60,9 +60,7 @@ func loadCredentials() (*CredentialsStore, error) {
 func createCredentials(
 	accountNames []string, options *CredentialsOptions) (
 	*CredentialsStore, map[string]error) {
-	sort.Strings(accountNames)
 	cs := &CredentialsStore{
-		accountNames:    accountNames,
 		sessionMap:      make(map[string]*session.Session),
 		accountIdToName: make(map[string]string),
 		accountNameToId: make(map[string]string),
@@ -80,6 +78,7 @@ func createCredentials(
 		if result.err != nil {
 			unloadableAccounts[result.accountName] = result.err
 		} else {
+			cs.accountNames = append(cs.accountNames, result.accountName)
 			cs.sessionMap[result.accountName] = result.awsSession
 			cs.accountIdToName[result.accountId] = result.accountName
 			cs.accountNameToId[result.accountName] = result.accountId
@@ -87,6 +86,7 @@ func createCredentials(
 		}
 	}
 	close(resultsChannel)
+	sort.Strings(cs.accountNames)
 	return cs, unloadableAccounts
 }
 

--- a/lib/awsutil/credentials.go
+++ b/lib/awsutil/credentials.go
@@ -20,19 +20,14 @@ type sessionResult struct {
 }
 
 func getCredentialsPath() string {
-	return getAwsPath(
-		*awsCredentialsFile, "AWS_CREDENTIAL_FILE", "credentials")
+	return getAwsPath("AWS_CREDENTIAL_FILE", "credentials")
 }
 
 func getConfigPath() string {
-	return getAwsPath(
-		*awsConfigFile, "AWS_CONFIG_FILE", "config")
+	return getAwsPath("AWS_CONFIG_FILE", "config")
 }
 
-func getAwsPath(cmdflag, environ, fileName string) string {
-	if cmdflag != "" {
-		return cmdflag
-	}
+func getAwsPath(environ, fileName string) string {
 	value := os.Getenv(environ)
 	if value != "" {
 		return value
@@ -43,10 +38,10 @@ func getAwsPath(cmdflag, environ, fileName string) string {
 
 func (c *CredentialsOptions) setDefaults() *CredentialsOptions {
 	if c.CredentialsPath == "" {
-		c.CredentialsPath = getCredentialsPath()
+		c.CredentialsPath = *awsCredentialsFile
 	}
 	if c.ConfigPath == "" {
-		c.ConfigPath = getConfigPath()
+		c.ConfigPath = *awsConfigFile
 	}
 	return c
 }


### PR DESCRIPTION
This PR is superior to the previous because caller can pass the location of the config files as a parameter.