### PR TITLE
Fix check in dominator which prevents unsafe changes.

### DIFF
--- a/dom/herd/sub.go
+++ b/dom/herd/sub.go
@@ -610,14 +610,14 @@ func (sub *Sub) checkForUnsafeChange(request subproto.UpdateRequest) bool {
 	if sub.requiredImage.Filter == nil {
 		return false // Sparse image: no deletions.
 	}
-	if len(sub.fileSystem.InodeTable)>>1 <
-		len(sub.requiredImage.FileSystem.InodeTable) {
-		return false
+	if len(sub.requiredImage.FileSystem.InodeTable) <
+		len(sub.fileSystem.InodeTable)>>1 {
+		return true
 	}
-	if len(request.PathsToDelete) < len(sub.fileSystem.InodeTable)>>1 {
-		return false
+	if len(request.PathsToDelete) > len(sub.fileSystem.InodeTable)>>1 {
+		return true
 	}
-	return true
+	return false
 }
 
 func (sub *Sub) cleanup(srpcClient *srpc.Client) {


### PR DESCRIPTION
The original safety check would trigger if the new image has fewer than
half the number of inodes as the sub. This erred on the side of caution.

If a new image replaces a large fraction of duplicate inodes with
hardlinks, then this safety check could trigger unnecessarily. This led
to commit 9cbeed1034f45bbf5d8bbeea22bef71e3ad5390a on 12-Jan-2018 which
changed the safety check to only trigger if the new image has fewer than
half the number of inodes as the sub AND if the number of recursive inode
deletions (i.e. deleting a directory tree counts as single deletion) is
more than half the number of inodes on the sub. This will not catch
changes such as replacing a sub with a much smaller image with large
directory trees being removed. It will catch a smaller image with fewer
hardlinks, but this is probably a rare case.

This change restores and increases the strength (sensitivity) of the
original safety check. The new safety check will trigger if new image has
fewer than half the number of inodes as the sub (i.e. new image is much
smaller) OR the number of recursive inode deletions is more than half the
number of inodes on the sub (i.e. new image is of similar size but many
fewer hardlinks).