### PR TITLE
Fix panic in imaginator when uploading image with no previous image.

### DIFF
--- a/imagebuilder/builder/getLatestImage.go
+++ b/imagebuilder/builder/getLatestImage.go
@@ -17,6 +17,9 @@ func getLatestImage(client *srpc.Client, imageStream string,
 	if err != nil {
 		return "", nil, err
 	}
+	if imageName == "" {
+		return "", nil, nil
+	}
 	if img, err := getImage(client, imageName, buildLog); err != nil {
 		return "", nil, err
 	} else {


### PR DESCRIPTION
This bug was introduced with the optimisations on 12-May-2018 in
commit 34f93e90e2e49984ea826fb997b00ba1bea2313e.