### PR TITLE
Imageserver fixes: single-thread object fetching and block replication clients during startup.

### DIFF
--- a/imageserver/rpcd/getImageUpdates.go
+++ b/imageserver/rpcd/getImageUpdates.go
@@ -11,6 +11,16 @@ func (t *srpcType) GetImageUpdates(conn *srpc.Conn, decoder srpc.Decoder,
 	defer conn.Flush()
 	t.logger.Printf("New image replication client connected from: %s\n",
 		conn.RemoteAddr())
+	select {
+	case <-t.finishedReplication:
+	default:
+		t.logger.Println(
+			"Blocking replication client until I've finished replicating")
+		<-t.finishedReplication
+		t.logger.Printf(
+			"Replication finished, unblocking replication client: %s\n",
+			conn.RemoteAddr())
+	}
 	t.incrementNumReplicationClients(true)
 	defer t.incrementNumReplicationClients(false)
 	addChannel := t.imageDataBase.RegisterAddNotifier()

--- a/imageserver/scanner/api.go
+++ b/imageserver/scanner/api.go
@@ -42,6 +42,7 @@ type ImageDataBase struct {
 	deduperLock      sync.Mutex
 	deduper          *stringutil.StringDeduplicator
 	pendingImageLock sync.Mutex
+	objectFetchLock  sync.Mutex
 	// Unprotected by any lock.
 	objectServer      objectserver.FullObjectServer
 	replicationMaster string


### PR DESCRIPTION
The imageserver was concurrently downloading objects during initial replication. If the same object was being downloaded concurrently, this could lead to failures:
- the first completed download could remove the temporary file of the second download, causing the second download to fail
- a downloaded object could be temporarily corrupted (truncated) if the second download overwrites the temporary file and the first download moves the object in-place
- a downloaded object could be permanently corrupted (truncated) if the second download overwrites but fails to complete and the first download moves the object in-place.
Fixed this by single-threading object downloads from the replication master. This is also more friendly to the master.

A rebuilt (empty) imageserver which was both a replication client and master (to other downstream clients) would cause the downstream clients to delete all their images while it fetches images from its master. Fixed this by blocking replication clients until all images fetched from master (upstream).