### PR TITLE
Trigger a reboot without specifying a service.

### DIFF
--- a/sub/rpcd/update.go
+++ b/sub/rpcd/update.go
@@ -147,6 +147,9 @@ func runTriggers(triggers []*triggers.Trigger, action string,
 			}
 			continue
 		}
+		if trigger.Service == "" {
+			continue
+		}
 		logger.Printf("%sAction: service %s %s\n",
 			logPrefix, trigger.Service, action)
 		if *disableTriggers {


### PR DESCRIPTION
Previously, it was not possible to trigger a reboot without
specifying a service to restart:

```
{
  "MatchLines": [...],
  "DoReboot": true,
}
```

Such a trigger would result in subd executing `service '' start`,
which fails and aborts the reboot.

Instead, interpret an empty Service as "don't restart any service",
but continue to respect DoReboot.