### PR TITLE
hypervisor/manager: Fix dropped error

### DIFF
--- a/hypervisor/manager/vm.go
+++ b/hypervisor/manager/vm.go
@@ -1811,6 +1811,9 @@ func (m *Manager) patchVmImage(conn *srpc.Conn,
 	}
 	_, err = os.Stat(
 		filepath.Join(vm.VolumeLocations[0].DirectoryToCleanup, "kernel"))
+	if err != nil {
+		return err
+	}
 	if writeBootloaderConfig {
 		err := bootInfo.WriteBootloaderConfig(rootDir, vm.logger)
 		if err != nil {


### PR DESCRIPTION
This fixes a declared but unused `err` variable.