### PR TITLE
builder-tool: support -alwaysShowBuildLog option for local builds.

### DIFF
--- a/cmd/builder-tool/main.go
+++ b/cmd/builder-tool/main.go
@@ -49,7 +49,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "Common flags:")
 	flag.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "Commands:")
-	fmt.Fprintln(os.Stderr, "  build-from-manifest manifestDir [stream-name]")
+	fmt.Fprintln(os.Stderr, "  build-from-manifest manifestDir stream-name")
 	fmt.Fprintln(os.Stderr, "  build-image stream-name [git-branch]")
 	fmt.Fprintln(os.Stderr, "  build-raw-from-manifest manifestDir rawFile")
 	fmt.Fprintln(os.Stderr, "  build-tree-from-manifest manifestDir")

--- a/cmd/builder-tool/manifest.go
+++ b/cmd/builder-tool/manifest.go
@@ -16,15 +16,28 @@ import (
 
 const filePerms = syscall.S_IRUSR | syscall.S_IRGRP | syscall.S_IROTH
 
+type logWriterType struct {
+	buffer bytes.Buffer
+}
+
 func buildFromManifestSubcommand(args []string, logger log.DebugLogger) {
 	srpcClient := getImageServerClient()
-	buildLog := &bytes.Buffer{}
+	logWriter := &logWriterType{}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
+	}
 	name, err := builder.BuildImageFromManifest(srpcClient, args[0], args[1],
-		*expiresIn, buildLog, logger)
+		*expiresIn, logWriter, logger)
 	if err != nil {
+		if !*alwaysShowBuildLog {
+			os.Stderr.Write(logWriter.Bytes())
+		}
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
 		fmt.Fprintf(os.Stderr, "Error processing manifest: %s\n", err)
-		io.Copy(os.Stderr, buildLog)
 		os.Exit(1)
+	}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
 	}
 	fmt.Println(name)
 	os.Exit(0)
@@ -60,4 +73,15 @@ func processManifestSubcommand(args []string, logger log.DebugLogger) {
 		io.Copy(os.Stdout, buildLog)
 	}
 	os.Exit(0)
+}
+
+func (w *logWriterType) Bytes() []byte {
+	return w.buffer.Bytes()
+}
+
+func (w *logWriterType) Write(p []byte) (int, error) {
+	if *alwaysShowBuildLog {
+		os.Stderr.Write(p)
+	}
+	return w.buffer.Write(p)
 }

--- a/cmd/builder-tool/manifest.go
+++ b/cmd/builder-tool/manifest.go
@@ -5,7 +5,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"syscall"
 
@@ -30,6 +29,8 @@ func buildFromManifestSubcommand(args []string, logger log.DebugLogger) {
 		*expiresIn, logWriter, logger)
 	if err != nil {
 		if !*alwaysShowBuildLog {
+			fmt.Fprintln(os.Stderr,
+				"Start of build log ==========================")
 			os.Stderr.Write(logWriter.Bytes())
 		}
 		fmt.Fprintln(os.Stderr, "End of build log ============================")
@@ -38,6 +39,13 @@ func buildFromManifestSubcommand(args []string, logger log.DebugLogger) {
 	}
 	if *alwaysShowBuildLog {
 		fmt.Fprintln(os.Stderr, "End of build log ============================")
+	} else {
+		err := fsutil.CopyToFile("build.log", filePerms, &logWriter.buffer,
+			uint64(logWriter.buffer.Len()))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing build log: %s\n", err)
+			os.Exit(1)
+		}
 	}
 	fmt.Println(name)
 	os.Exit(0)
@@ -45,32 +53,60 @@ func buildFromManifestSubcommand(args []string, logger log.DebugLogger) {
 
 func buildTreeFromManifestSubcommand(args []string, logger log.DebugLogger) {
 	srpcClient := getImageServerClient()
-	buildLog := &bytes.Buffer{}
-	rootDir, err := builder.BuildTreeFromManifest(srpcClient, args[0], buildLog,
-		logger)
+	logWriter := &logWriterType{}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
+	}
+	rootDir, err := builder.BuildTreeFromManifest(srpcClient, args[0],
+		logWriter, logger)
 	if err != nil {
+		if !*alwaysShowBuildLog {
+			fmt.Fprintln(os.Stderr,
+				"Start of build log ==========================")
+			os.Stderr.Write(logWriter.Bytes())
+		}
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
 		fmt.Fprintf(os.Stderr, "Error processing manifest: %s\n", err)
-		io.Copy(os.Stderr, buildLog)
 		os.Exit(1)
+	}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
+	} else {
+		err := fsutil.CopyToFile("build.log", filePerms, &logWriter.buffer,
+			uint64(logWriter.buffer.Len()))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing build log: %s\n", err)
+			os.Exit(1)
+		}
 	}
 	fmt.Println(rootDir)
-	err = fsutil.CopyToFile("build.log", filePerms, buildLog,
-		uint64(buildLog.Len()))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing build log: %s\n", err)
-		os.Exit(1)
-	}
 	os.Exit(0)
 }
 
 func processManifestSubcommand(args []string, logger log.DebugLogger) {
-	buildLog := &bytes.Buffer{}
-	if err := builder.ProcessManifest(args[0], args[1], buildLog); err != nil {
+	logWriter := &logWriterType{}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
+	}
+	if err := builder.ProcessManifest(args[0], args[1], logWriter); err != nil {
+		if !*alwaysShowBuildLog {
+			fmt.Fprintln(os.Stderr,
+				"Start of build log ==========================")
+			os.Stderr.Write(logWriter.Bytes())
+		}
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
 		fmt.Fprintf(os.Stderr, "Error processing manifest: %s\n", err)
-		io.Copy(os.Stderr, buildLog)
 		os.Exit(1)
+	}
+	if *alwaysShowBuildLog {
+		fmt.Fprintln(os.Stderr, "End of build log ============================")
 	} else {
-		io.Copy(os.Stdout, buildLog)
+		err := fsutil.CopyToFile("build.log", filePerms, &logWriter.buffer,
+			uint64(logWriter.buffer.Len()))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing build log: %s\n", err)
+			os.Exit(1)
+		}
 	}
 	os.Exit(0)
 }

--- a/imagebuilder/builder/api.go
+++ b/imagebuilder/builder/api.go
@@ -156,7 +156,7 @@ func BuildImageFromManifest(client *srpc.Client, manifestDir, streamName string,
 }
 
 func BuildTreeFromManifest(client *srpc.Client, manifestDir string,
-	buildLog *bytes.Buffer, logger log.Logger) (string, error) {
+	buildLog io.Writer, logger log.Logger) (string, error) {
 	return buildTreeFromManifest(client, manifestDir, buildLog)
 }
 
@@ -165,7 +165,7 @@ func ProcessManifest(manifestDir, rootDir string, buildLog io.Writer) error {
 }
 
 func UnpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
-	rootDir string, buildLog buildLogger) error {
+	rootDir string, buildLog io.Writer) error {
 	_, err := unpackImageAndProcessManifest(client, manifestDir, rootDir, true,
 		buildLog)
 	return err

--- a/imagebuilder/builder/image.go
+++ b/imagebuilder/builder/image.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -269,7 +268,7 @@ func buildImageFromManifestAndUpload(client *srpc.Client, manifestDir string,
 }
 
 func buildTreeFromManifest(client *srpc.Client, manifestDir string,
-	buildLog *bytes.Buffer) (string, error) {
+	buildLog io.Writer) (string, error) {
 	rootDir, err := makeTempDirectory("", "tree")
 	if err != nil {
 		return "", err
@@ -327,7 +326,7 @@ func loadTriggers(manifestDir string) (*triggers.Triggers, bool, error) {
 
 func unpackImage(client *srpc.Client, streamName string,
 	maxSourceAge, expiresIn time.Duration, rootDir string,
-	buildLog buildLogger) (*sourceImageInfoType, error) {
+	buildLog io.Writer) (*sourceImageInfoType, error) {
 	imageName, sourceImage, err := getLatestImage(client, streamName, buildLog)
 	if err != nil {
 		return nil, err

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -19,7 +19,7 @@ import (
 
 func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 	rootDir string, applyFilter bool,
-	buildLog buildLogger) (manifestType, error) {
+	buildLog io.Writer) (manifestType, error) {
 	manifestFile := path.Join(manifestDir, "manifest")
 	var manifestConfig manifestConfigType
 	if err := json.ReadFromFile(manifestFile, &manifestConfig); err != nil {

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -37,7 +37,7 @@ func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 		return manifestType{},
 			errors.New("error processing manifest: " + err.Error())
 	}
-	if applyFilter {
+	if applyFilter && manifestConfig.Filter != nil {
 		err := util.DeletedFilteredFiles(rootDir, manifestConfig.Filter)
 		if err != nil {
 			return manifestType{}, err


### PR DESCRIPTION
This enables real-time display of build logs in builder-tool when building locally.
Minor fix for built-in help.
Fix a panic when building a tree locally, which never has a filter (bug introduced in a previous commit).