### PR TITLE
Imaginator: support bind mounting into build workspace.

### DIFF
--- a/cmd/builder-tool/buildRaw.go
+++ b/cmd/builder-tool/buildRaw.go
@@ -79,7 +79,7 @@ func buildRawFromManifest(manifestDir, rawFilename string,
 	}
 	defer syscall.Unmount(rootDir, 0)
 	err = builder.UnpackImageAndProcessManifest(srpcClient, manifestDir,
-		rootDir, buildLog)
+		rootDir, bindMounts, buildLog)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error processing manifest: %s\n", err)
 		io.Copy(os.Stderr, buildLog)

--- a/cmd/builder-tool/main.go
+++ b/cmd/builder-tool/main.go
@@ -18,6 +18,7 @@ import (
 var (
 	alwaysShowBuildLog = flag.Bool("alwaysShowBuildLog", false,
 		"If true, show build log even for successful builds")
+	bindMounts         flagutil.StringList
 	imaginatorHostname = flag.String("imaginatorHostname", "localhost",
 		"Hostname of image build server")
 	imaginatorPortNum = flag.Uint("imaginatorPortNum",
@@ -40,6 +41,8 @@ var (
 )
 
 func init() {
+	flag.Var(&bindMounts, "bindMounts",
+		"Comma separated list of directories to bind mount into build workspace")
 	flag.Var(&rawSize, "rawSize", "Size of RAW file to create")
 }
 

--- a/cmd/builder-tool/manifest.go
+++ b/cmd/builder-tool/manifest.go
@@ -26,7 +26,7 @@ func buildFromManifestSubcommand(args []string, logger log.DebugLogger) {
 		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
 	}
 	name, err := builder.BuildImageFromManifest(srpcClient, args[0], args[1],
-		*expiresIn, logWriter, logger)
+		*expiresIn, bindMounts, logWriter, logger)
 	if err != nil {
 		if !*alwaysShowBuildLog {
 			fmt.Fprintln(os.Stderr,
@@ -58,7 +58,7 @@ func buildTreeFromManifestSubcommand(args []string, logger log.DebugLogger) {
 		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
 	}
 	rootDir, err := builder.BuildTreeFromManifest(srpcClient, args[0],
-		logWriter, logger)
+		bindMounts, logWriter, logger)
 	if err != nil {
 		if !*alwaysShowBuildLog {
 			fmt.Fprintln(os.Stderr,
@@ -88,7 +88,8 @@ func processManifestSubcommand(args []string, logger log.DebugLogger) {
 	if *alwaysShowBuildLog {
 		fmt.Fprintln(os.Stderr, "Start of build log ==========================")
 	}
-	if err := builder.ProcessManifest(args[0], args[1], logWriter); err != nil {
+	err := builder.ProcessManifest(args[0], args[1], bindMounts, logWriter)
+	if err != nil {
 		if !*alwaysShowBuildLog {
 			fmt.Fprintln(os.Stderr,
 				"Start of build log ==========================")

--- a/imagebuilder/builder/api.go
+++ b/imagebuilder/builder/api.go
@@ -42,6 +42,7 @@ type buildResultType struct {
 }
 
 type masterConfigurationType struct {
+	BindMounts                []string                    `json:",omitempty"`
 	BootstrapStreams          map[string]*bootstrapStream `json:",omitempty"`
 	ImageStreamsCheckInterval uint                        `json:",omitempty"`
 	ImageStreamsToAutoRebuild []string                    `json:",omitempty"`
@@ -94,6 +95,7 @@ type sourceImageInfoType struct {
 }
 
 type Builder struct {
+	bindMounts                []string
 	stateDir                  string
 	imageServerAddress        string
 	logger                    log.Logger
@@ -144,29 +146,32 @@ func (b *Builder) WriteHtml(writer io.Writer) {
 }
 
 func BuildImageFromManifest(client *srpc.Client, manifestDir, streamName string,
-	expiresIn time.Duration, buildLog buildLogger, logger log.Logger) (
+	expiresIn time.Duration, bindMounts []string, buildLog buildLogger,
+	logger log.Logger) (
 	string, error) {
 	_, name, err := buildImageFromManifestAndUpload(client, manifestDir,
 		proto.BuildImageRequest{
 			StreamName: streamName,
 			ExpiresIn:  expiresIn,
 		},
-		buildLog)
+		bindMounts, buildLog)
 	return name, err
 }
 
 func BuildTreeFromManifest(client *srpc.Client, manifestDir string,
-	buildLog io.Writer, logger log.Logger) (string, error) {
-	return buildTreeFromManifest(client, manifestDir, buildLog)
+	bindMounts []string, buildLog io.Writer,
+	logger log.Logger) (string, error) {
+	return buildTreeFromManifest(client, manifestDir, bindMounts, buildLog)
 }
 
-func ProcessManifest(manifestDir, rootDir string, buildLog io.Writer) error {
-	return processManifest(manifestDir, rootDir, buildLog)
+func ProcessManifest(manifestDir, rootDir string, bindMounts []string,
+	buildLog io.Writer) error {
+	return processManifest(manifestDir, rootDir, bindMounts, buildLog)
 }
 
 func UnpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
-	rootDir string, buildLog io.Writer) error {
-	_, err := unpackImageAndProcessManifest(client, manifestDir, rootDir, true,
-		buildLog)
+	rootDir string, bindMounts []string, buildLog io.Writer) error {
+	_, err := unpackImageAndProcessManifest(client, manifestDir, rootDir,
+		bindMounts, true, buildLog)
 	return err
 }

--- a/imagebuilder/builder/load.go
+++ b/imagebuilder/builder/load.go
@@ -59,6 +59,7 @@ func load(confUrl, variablesFile, stateDir, imageServerAddress string,
 		variables = make(map[string]string)
 	}
 	b := &Builder{
+		bindMounts:                masterConfiguration.BindMounts,
 		stateDir:                  stateDir,
 		imageServerAddress:        imageServerAddress,
 		logger:                    logger,

--- a/lib/wsyscall/api.go
+++ b/lib/wsyscall/api.go
@@ -4,6 +4,7 @@ import "syscall"
 
 const (
 	MS_BIND = 1 << iota
+	MS_RDONLY
 
 	RUSAGE_CHILDREN = iota
 	RUSAGE_SELF

--- a/lib/wsyscall/wrappers_linux.go
+++ b/lib/wsyscall/wrappers_linux.go
@@ -89,6 +89,9 @@ func mount(source string, target string, fstype string, flags uintptr,
 	if flags&MS_BIND != 0 {
 		linuxFlags |= syscall.MS_BIND
 	}
+	if flags&MS_RDONLY != 0 {
+		linuxFlags |= syscall.MS_RDONLY
+	}
 	return syscall.Mount(source, target, fstype, linuxFlags, data)
 }
 


### PR DESCRIPTION
This allows the administrator to add bind mounts from the host into the build workspaces. This is useful if a package repository is available on the host file-system (whether local or via NFS). This can improve build times and reduce memory consumption as packages do not have to be downloaded into the build workspaces.