### PR TITLE
Improve symlink handling in lib/fsutil.CopyTree() function.

### DIFF
--- a/lib/fsutil/copy.go
+++ b/lib/fsutil/copy.go
@@ -82,11 +82,17 @@ func copyTree(destDir, sourceDir string,
 				return err
 			}
 		case syscall.S_IFLNK:
-			target, err := os.Readlink(sourceFilename)
+			sourceTarget, err := os.Readlink(sourceFilename)
 			if err != nil {
 				return errors.New(sourceFilename + ": " + err.Error())
 			}
-			if err := os.Symlink(target, destFilename); err != nil {
+			if destTarget, err := os.Readlink(destFilename); err == nil {
+				if sourceTarget == destTarget {
+					continue
+				}
+			}
+			os.Remove(destFilename)
+			if err := os.Symlink(sourceTarget, destFilename); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
This fixes the case where the target directory has an existing entry, which caused creating the target symlink to fail. Now remove the target symlink (unless it's the same as the source symlink) before creating the target.