### PR TITLE
Installer: encrypt all non-root file-systems.

### DIFF
--- a/cmd/installer/lib.go
+++ b/cmd/installer/lib.go
@@ -73,8 +73,11 @@ func run(name, chroot string, logger log.DebugLogger, args ...string) error {
 	} else {
 		logger.Debugf(0, "running: %s %s\n", name, strings.Join(args, " "))
 	}
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error running: %s: %s", name, output)
+	} else {
+		return nil
+	}
 }
 
 func (wc *writeCloser) Close() error {


### PR DESCRIPTION
The installer will now encrypt all non-root file-systems, storing an access key on the root file-system.
Performance of the installer has been improved by making the operations heavily concurrent. For a system with as few as 4 drives, this improves installation time by over one minute.