### PR TITLE
Installer: flush log before saving and wait for remote shells to exit.

### DIFF
--- a/cmd/installer/configureLocalNetwork.go
+++ b/cmd/installer/configureLocalNetwork.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Symantec/Dominator/lib/fsutil"
 	"github.com/Symantec/Dominator/lib/json"
 	"github.com/Symantec/Dominator/lib/log"
 	libnet "github.com/Symantec/Dominator/lib/net"
@@ -147,7 +148,7 @@ func loadTftpFiles(tftpServer net.IP, logger log.DebugLogger) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(*tftpDirectory, dirPerms); err != nil {
+	if err := os.MkdirAll(*tftpDirectory, fsutil.DirPerms); err != nil {
 		return err
 	}
 	for _, name := range tftpFiles {

--- a/cmd/installer/configureNetwork.go
+++ b/cmd/installer/configureNetwork.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Symantec/Dominator/lib/fsutil"
 	"github.com/Symantec/Dominator/lib/log"
 	libnet "github.com/Symantec/Dominator/lib/net"
 	"github.com/Symantec/Dominator/lib/net/configurator"
@@ -31,7 +32,7 @@ func configureNetwork(machineInfo fm_proto.GetMachineInfoResponse,
 	interfaces map[string]net.Interface, logger log.DebugLogger) error {
 	hostname := strings.Split(machineInfo.Machine.Hostname, ".")[0]
 	err := ioutil.WriteFile(filepath.Join(*mountPoint, "etc", "hostname"),
-		[]byte(hostname+"\n"), filePerms)
+		[]byte(hostname+"\n"), fsutil.PublicFilePerms)
 	if err != nil {
 		return err
 	}

--- a/cmd/installer/objects.go
+++ b/cmd/installer/objects.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Symantec/Dominator/lib/format"
+	"github.com/Symantec/Dominator/lib/fsutil"
 	"github.com/Symantec/Dominator/lib/hash"
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/Dominator/lib/objectcache"
@@ -187,7 +188,7 @@ func (cache *objectsCache) getNextObject(hashVal hash.Hash,
 	}
 	hashName := filepath.Join(*objectsDirectory,
 		objectcache.HashToFilename(hashVal))
-	if err := os.MkdirAll(filepath.Dir(hashName), dirPerms); err != nil {
+	if err := os.MkdirAll(filepath.Dir(hashName), fsutil.DirPerms); err != nil {
 		return err
 	}
 	defer reader.Close()
@@ -223,7 +224,8 @@ func (cache *objectsCache) handleFile(filename string, copy bool,
 		}
 		hashName := filepath.Join(*objectsDirectory,
 			objectcache.HashToFilename(hashVal))
-		if err := os.MkdirAll(filepath.Dir(hashName), dirPerms); err != nil {
+		err := os.MkdirAll(filepath.Dir(hashName), fsutil.DirPerms)
+		if err != nil {
 			return err
 		}
 		if copy {
@@ -281,7 +283,7 @@ func (cache *objectsCache) scanCache(topDir, subpath string) error {
 
 func (cache *objectsCache) scanRoot(
 	requiredObjects map[hash.Hash]uint64) error {
-	if err := os.Mkdir(*objectsDirectory, dirPerms); err != nil {
+	if err := os.Mkdir(*objectsDirectory, fsutil.DirPerms); err != nil {
 		return err
 	}
 	err := wsyscall.Mount("none", *objectsDirectory, "tmpfs", 0, "")


### PR DESCRIPTION
Improve installation debugging by adding an extra timeout before rebooting if remote shells are connected.
Ensure logs are flushed prior to rebooting.
Do not erase root partition if it has been cleared by TRIM command.