### PR TITLE
Sort matched triggers by service name

### DIFF
--- a/lib/triggers/match.go
+++ b/lib/triggers/match.go
@@ -1,5 +1,9 @@
 package triggers
 
+import (
+	"sort"
+)
+
 func (triggers *Triggers) match(line string) {
 	triggers.compile()
 	if triggers.matchedTriggers == nil {
@@ -26,6 +30,9 @@ func (triggers *Triggers) getMatchedTriggers() []*Trigger {
 	for trigger := range triggers.matchedTriggers {
 		mTriggers = append(mTriggers, trigger)
 	}
+	sort.Slice(mTriggers, func(i, j int) bool {
+		return mTriggers[i].Service < mTriggers[j].Service
+	})
 	triggers.matchedTriggers = nil
 	triggers.unmatchedTriggers = nil
 	return mTriggers


### PR DESCRIPTION
Currently dominator triggers service stop/start in a random order because the matched triggers are maintained in a map. Sorting matched triggers by service name allows us stop and start to happen in a determined order.